### PR TITLE
fix: activate all registered tools on session start (#13)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -81,6 +81,15 @@ export default function (pi: ExtensionAPI) {
       maxTokens: model.maxTokens,
     }));
 
+    // Ensure all registered tools are active so pi can execute them.
+    // Some tools (find, grep, ls) are registered but not activated by default.
+    pi.on("session_start", async () => {
+      const allTools = pi.getAllTools();
+      if (Array.isArray(allTools)) {
+        pi.setActiveTools(allTools.map((t: any) => t.name));
+      }
+    });
+
     pi.registerProvider(PROVIDER_ID, {
       baseUrl: "pi-claude-cli",
       apiKey: "unused",

--- a/tests/provider.test.ts
+++ b/tests/provider.test.ts
@@ -75,7 +75,7 @@ import { streamViaCli } from "../src/provider";
 describe("provider registration (default export)", () => {
   it("registers provider with ID pi-claude-cli", async () => {
     const registerProvider = vi.fn();
-    const mockPi = { registerProvider } as any;
+    const mockPi = { registerProvider, on: vi.fn() } as any;
 
     // Dynamic import to get the default export
     const mod = await import("../index");
@@ -87,7 +87,7 @@ describe("provider registration (default export)", () => {
 
   it("registers provider with correct config shape", async () => {
     const registerProvider = vi.fn();
-    const mockPi = { registerProvider } as any;
+    const mockPi = { registerProvider, on: vi.fn() } as any;
 
     const mod = await import("../index");
     mod.default(mockPi);
@@ -104,7 +104,7 @@ describe("provider registration (default export)", () => {
 
   it("derives models from getModels('anthropic') with correct fields", async () => {
     const registerProvider = vi.fn();
-    const mockPi = { registerProvider } as any;
+    const mockPi = { registerProvider, on: vi.fn() } as any;
 
     const mod = await import("../index");
     mod.default(mockPi);


### PR DESCRIPTION
## Summary

Fixes #13 — `Glob`→`find` and `Grep`→`grep` tool mappings now work because the tools are activated on session start.

**Root cause:** Pi only activates `read`/`bash`/`edit`/`write` by default. Other tools like `find`, `grep`, `ls` are registered in the tool registry but not included in the active set. The agent loop only executes active tools, so mapped calls returned "Tool find not found".

**Fix:** Call `pi.setActiveTools()` on `session_start` to activate all registered tools.

## Test plan

- [x] 296 tests pass
- [x] TypeScript and lint clean
- [x] Manual E2E in GSD: "find the readme" → finds README.md (no more loop)
- [x] Manual E2E in GSD: read, write, edit, bash tools still work