### PR TITLE
fix: reuse Claude CLI sessions across follow-up turns

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -16,9 +16,10 @@
 
 import { createInterface } from "node:readline";
 import {
-  AssistantMessageEventStream,
+  createAssistantMessageEventStream,
   type Model,
   type SimpleStreamOptions,
+  type AssistantMessageEventStream,
 } from "@mariozechner/pi-ai";
 import {
   buildPrompt,
@@ -75,9 +76,7 @@ export function streamViaCli(
   context: { messages: any[]; systemPrompt?: string },
   options?: StreamViaCLiOptions,
 ): AssistantMessageEventStream {
-  // @ts-expect-error — tsc can't verify AssistantMessageEventStream is a value
-  // through pi-ai's `export *` re-export chain. The class constructor exists at runtime.
-  const stream = new AssistantMessageEventStream();
+  const stream = createAssistantMessageEventStream();
 
   (async () => {
     let proc: ReturnType<typeof spawnClaude> | undefined;

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -39,6 +39,11 @@ import { createEventBridge } from "./event-bridge.js";
 import { handleControlRequest } from "./control-handler.js";
 import { mapThinkingEffort } from "./thinking-config.js";
 import { isPiKnownClaudeTool } from "./tool-mapping.js";
+import {
+  clearSessionId,
+  getSessionId,
+  setSessionId,
+} from "./session-manager.js";
 /** Inactivity timeout: kill subprocess if no stdout for 180 seconds (3 minutes). */
 const INACTIVITY_TIMEOUT_MS = 180_000;
 
@@ -80,14 +85,14 @@ export function streamViaCli(
 
     try {
       const cwd = options?.cwd ?? process.cwd();
+      const sessionKey = options?.sessionId ?? cwd;
 
-      // Resume if pi provides a session ID AND this isn't the first turn.
-      // Pi passes sessionId on every call (including first), but we can only
-      // --resume a CLI session that already exists on disk from a prior turn.
+      // Prefer an explicit pi session when available, otherwise fall back to a
+      // cwd-scoped session tracked by this extension.
       const resumeSessionId =
-        options?.sessionId && context.messages.length > 1
+        (options?.sessionId && context.messages.length > 1
           ? options.sessionId
-          : undefined;
+          : undefined) ?? getSessionId(sessionKey);
 
       // Build prompt: if resuming, only send the latest user turn;
       // otherwise build the full flattened conversation history
@@ -200,6 +205,7 @@ export function streamViaCli(
       // Handle process error -- use endStreamWithError for guard
       proc.on("error", (err: Error) => {
         if (broken) return; // Break-early killed the process intentionally
+        clearSessionId(sessionKey);
         const stderr = getStderr();
         endStreamWithError(stderr || err.message);
       });
@@ -209,6 +215,7 @@ export function streamViaCli(
         clearTimeout(inactivityTimer);
         if (broken) return; // Break-early kill, expected
         if (code !== 0 && code !== null) {
+          clearSessionId(sessionKey);
           const stderr = getStderr();
           const message = stderr
             ? `Claude CLI exited with code ${code}: ${stderr.trim()}`
@@ -270,8 +277,16 @@ export function streamViaCli(
           }
         } else if (msg.type === "control_request") {
           handleControlRequest(msg, proc!.stdin!);
+        } else if (msg.type === "system") {
+          if (msg.session_id) {
+            setSessionId(sessionKey, msg.session_id);
+          }
         } else if (msg.type === "result") {
+          if (msg.session_id) {
+            setSessionId(sessionKey, msg.session_id);
+          }
           if (msg.subtype === "error") {
+            clearSessionId(sessionKey);
             endStreamWithError(msg.error ?? "Unknown error from Claude CLI");
           }
           // For both success and error: clean up the subprocess

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -1,0 +1,26 @@
+/**
+ * Session manager for tracking Claude CLI session IDs across subprocess turns.
+ *
+ * The provider falls back to a cwd-scoped session when pi does not supply a
+ * stable sessionId option. Without this, every follow-up turn replays the full
+ * flattened conversation and token usage grows unnecessarily.
+ */
+
+const sessionIds = new Map<string, string>();
+
+export function getSessionId(key: string): string | undefined {
+  return sessionIds.get(key);
+}
+
+export function setSessionId(key: string, sessionId: string): void {
+  if (!key || !sessionId) return;
+  sessionIds.set(key, sessionId);
+}
+
+export function clearSessionId(key: string): void {
+  sessionIds.delete(key);
+}
+
+export function clearAllSessionIds(): void {
+  sessionIds.clear();
+}

--- a/tests/provider.test.ts
+++ b/tests/provider.test.ts
@@ -71,6 +71,10 @@ vi.mock("@mariozechner/pi-ai", () => ({
 
 import spawn from "cross-spawn";
 import { streamViaCli } from "../src/provider";
+import {
+  clearAllSessionIds,
+  getSessionId,
+} from "../src/session-manager";
 
 describe("provider registration (default export)", () => {
   it("registers provider with ID pi-claude-cli", async () => {
@@ -125,10 +129,12 @@ describe("streamViaCli", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    clearAllSessionIds();
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    clearAllSessionIds();
   });
 
   it("returns an AssistantMessageEventStream", () => {
@@ -1787,6 +1793,217 @@ describe("streamViaCli", () => {
   });
 
   describe("session resume via options.sessionId", () => {
+    it("captures session_id from result and resumes automatically on next call", async () => {
+      const model = mockModels[0] as any;
+
+      const context1 = {
+        messages: [{ role: "user", content: "Hello" }],
+      };
+
+      streamViaCli(model, context1);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const proc1 = (spawn as any).mock.results[0].value;
+      const args1 = (spawn as any).mock.calls[0][1] as string[];
+      expect(args1).not.toContain("--resume");
+
+      const firstTurnLines = [
+        JSON.stringify({
+          type: "system",
+          subtype: "init",
+          session_id: "sess-first",
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "message_start",
+            message: { usage: { input_tokens: 10, output_tokens: 0 } },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "message_stop" },
+        }),
+        JSON.stringify({
+          type: "result",
+          subtype: "success",
+          session_id: "sess-first",
+          result: "ok",
+        }),
+      ];
+
+      for (const line of firstTurnLines) {
+        proc1.stdout.write(line + "\n");
+      }
+      proc1.stdout.end();
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(getSessionId(process.cwd())).toBe("sess-first");
+
+      const context2 = {
+        messages: [
+          { role: "user", content: "Hello" },
+          { role: "assistant", content: "Hi there" },
+          { role: "user", content: "Follow-up" },
+        ],
+      };
+
+      streamViaCli(model, context2);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const args2 = (spawn as any).mock.calls[1][1] as string[];
+      expect(args2).toContain("--resume");
+      const resumeIdx = args2.indexOf("--resume");
+      expect(args2[resumeIdx + 1]).toBe("sess-first");
+
+      const proc2 = (spawn as any).mock.results[1].value;
+      const written = proc2.stdin.write.mock.calls[0][0] as string;
+      const parsed = JSON.parse(written.trim());
+      expect(parsed.message.content).toBe("Follow-up");
+    });
+
+    it("clears stored session on CLI error result and falls back to full prompt", async () => {
+      const model = mockModels[0] as any;
+
+      const context1 = {
+        messages: [{ role: "user", content: "Hello" }],
+      };
+
+      streamViaCli(model, context1);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const proc1 = (spawn as any).mock.results[0].value;
+      const successLines = [
+        JSON.stringify({
+          type: "system",
+          subtype: "init",
+          session_id: "sess-good",
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "message_start",
+            message: { usage: { input_tokens: 10, output_tokens: 0 } },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "message_stop" },
+        }),
+        JSON.stringify({
+          type: "result",
+          subtype: "success",
+          session_id: "sess-good",
+          result: "ok",
+        }),
+      ];
+
+      for (const line of successLines) {
+        proc1.stdout.write(line + "\n");
+      }
+      proc1.stdout.end();
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(getSessionId(process.cwd())).toBe("sess-good");
+
+      const context2 = {
+        messages: [
+          { role: "user", content: "Hello" },
+          { role: "assistant", content: "Hi" },
+          { role: "user", content: "Break things" },
+        ],
+      };
+
+      streamViaCli(model, context2);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const proc2 = (spawn as any).mock.results[1].value;
+      proc2.stdout.write(
+        JSON.stringify({
+          type: "result",
+          subtype: "error",
+          error: "Something failed",
+        }) + "\n",
+      );
+      proc2.stdout.end();
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(getSessionId(process.cwd())).toBeUndefined();
+
+      const context3 = {
+        messages: [{ role: "user", content: "Try again" }],
+      };
+
+      streamViaCli(model, context3);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const args3 = (spawn as any).mock.calls[2][1] as string[];
+      expect(args3).not.toContain("--resume");
+    });
+
+    it("captures session_id from system init before break-early result handling", async () => {
+      const model = mockModels[0] as any;
+      const context = {
+        messages: [{ role: "user", content: "Read a file" }],
+      };
+
+      streamViaCli(model, context);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const proc = (spawn as any).mock.results[0].value;
+      const lines = [
+        JSON.stringify({
+          type: "system",
+          subtype: "init",
+          session_id: "sess-break-early",
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "message_start",
+            message: { usage: { input_tokens: 10, output_tokens: 0 } },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: {
+              type: "tool_use",
+              id: "tool_read",
+              name: "Read",
+              input: "",
+            },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop", index: 0 },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "message_delta",
+            delta: { stop_reason: "tool_use" },
+            usage: { output_tokens: 5 },
+          },
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "message_stop" },
+        }),
+      ];
+
+      for (const line of lines) {
+        proc.stdout.write(line + "\n");
+      }
+      proc.stdout.end();
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(getSessionId(process.cwd())).toBe("sess-break-early");
+    });
+
     it("passes --resume when sessionId option is provided on subsequent turn", async () => {
       const model = mockModels[0] as any;
       const context = {

--- a/tests/provider.test.ts
+++ b/tests/provider.test.ts
@@ -66,6 +66,9 @@ const { MockAssistantMessageEventStream } = vi.hoisted(() => {
 vi.mock("@mariozechner/pi-ai", () => ({
   getModels: vi.fn(() => mockModels),
   AssistantMessageEventStream: MockAssistantMessageEventStream,
+  createAssistantMessageEventStream: vi.fn(
+    () => new (MockAssistantMessageEventStream as any)(),
+  ),
   calculateCost: vi.fn(),
 }));
 

--- a/tests/provider.test.ts
+++ b/tests/provider.test.ts
@@ -74,10 +74,7 @@ vi.mock("@mariozechner/pi-ai", () => ({
 
 import spawn from "cross-spawn";
 import { streamViaCli } from "../src/provider";
-import {
-  clearAllSessionIds,
-  getSessionId,
-} from "../src/session-manager";
+import { clearAllSessionIds, getSessionId } from "../src/session-manager";
 
 describe("provider registration (default export)", () => {
   it("registers provider with ID pi-claude-cli", async () => {


### PR DESCRIPTION
## Summary

Fix excessive token usage on follow-up turns by reusing Claude CLI sessions even when pi does not provide a stable `sessionId`.

Before this change, the provider only resumed sessions when pi explicitly passed a reusable `sessionId`. In real use that was not reliable, so many follow-up turns fell back to rebuilding and resending the full flattened conversation history, which drove token usage up unnecessarily.

This change adds local session tracking so the provider can capture Claude CLI `session_id` values and reuse them with `--resume` on later turns.

It also updates the provider to use the supported assistant stream factory so the extension works correctly under current GSD runtime behavior.

## What Changed

- add a small in-memory session manager for Claude CLI `session_id` values
- fall back to a cwd-scoped cached session when pi does not supply a stable `sessionId`
- capture `session_id` from both early `system` init messages and final `result` messages
- clear cached session state on CLI errors/crashes
- add regression tests covering automatic resume, break-early session capture, and session clearing after errors
- switch provider stream creation to `createAssistantMessageEventStream()` for GSD compatibility

## Why

The token usage issue was caused by repeated full-history replay on follow-up turns. Reusing Claude CLI sessions means only incremental turn content needs to be sent after the first request.

## Validation Completed

- npm test
- npm run typecheck
- npm run lint