### PR TITLE
Pass through Claude CLI context limit failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ The extension registers as a custom pi provider exposing all Claude models. Each
 
 ## Installation
 
+For vanilla `pi`:
+
+```bash
+pi install npm:pi-claude-cli
+```
+
 Add to `~/.gsd/agent/settings.json`:
 
 ```json

--- a/src/event-bridge.ts
+++ b/src/event-bridge.ts
@@ -21,6 +21,7 @@ import {
 interface TrackedToolBlock {
   type: "tool_use";
   index: number;
+  contentIndex: number;
   id: string;
   name: string; // Already mapped to pi name
   claudeName: string; // Original Claude name for arg translation
@@ -39,7 +40,9 @@ type TrackedBlock = TrackedContentBlock | TrackedToolBlock;
  */
 export interface EventBridge {
   handleEvent(event: ClaudeApiEvent): void;
+  emitEphemeralStatus(text: string): void;
   getOutput(): AssistantMessage;
+  getFinalOutput(): AssistantMessage;
 }
 
 /**
@@ -96,6 +99,7 @@ export function createEventBridge(
   };
 
   let started = false;
+  let lastEphemeralStatus: string | undefined;
 
   function handleEvent(event: ClaudeApiEvent): void {
     // Emit start event on first message — tells pi to begin incremental rendering
@@ -147,24 +151,28 @@ export function createEventBridge(
     const blockType = event.content_block?.type;
 
     if (blockType === "text") {
+      const contentIndex = output.content.length;
       const block: TrackedContentBlock = {
         type: "text",
         text: "",
         index: event.index ?? 0,
+        contentIndex,
       };
       blocks.push(block);
       output.content.push({ type: "text" as const, text: "" });
 
       stream.push({
         type: "text_start",
-        contentIndex: output.content.length - 1,
+        contentIndex,
         partial: output,
       });
     } else if (blockType === "thinking") {
+      const contentIndex = output.content.length;
       const block: TrackedContentBlock = {
         type: "thinking",
         text: "",
         index: event.index ?? 0,
+        contentIndex,
       };
       blocks.push(block);
       output.content.push({
@@ -175,7 +183,7 @@ export function createEventBridge(
 
       stream.push({
         type: "thinking_start",
-        contentIndex: output.content.length - 1,
+        contentIndex,
         partial: output,
       });
     } else if (blockType === "tool_use") {
@@ -189,10 +197,12 @@ export function createEventBridge(
 
       const piName = mapClaudeToolNameToPi(claudeName);
       const id = event.content_block!.id!;
+      const contentIndex = output.content.length;
 
       const block: TrackedToolBlock = {
         type: "tool_use",
         index: event.index ?? 0,
+        contentIndex,
         id,
         name: piName,
         claudeName,
@@ -209,7 +219,7 @@ export function createEventBridge(
 
       stream.push({
         type: "toolcall_start",
-        contentIndex: output.content.length - 1,
+        contentIndex,
         partial: output,
       });
     }
@@ -224,14 +234,15 @@ export function createEventBridge(
       if (idx === -1) return;
 
       const block = blocks[idx];
+      const contentIndex = block.contentIndex;
       if (block.type === "text") {
         block.text += event.delta!.text;
-        const contentBlock = output.content[idx] as TextContent;
+        const contentBlock = output.content[contentIndex] as TextContent;
         contentBlock.text = block.text;
 
         stream.push({
           type: "text_delta",
-          contentIndex: idx,
+          contentIndex,
           delta: event.delta!.text,
           partial: output,
         });
@@ -244,14 +255,15 @@ export function createEventBridge(
       if (idx === -1) return;
 
       const block = blocks[idx];
+      const contentIndex = block.contentIndex;
       if (block.type === "thinking") {
         block.text += event.delta!.thinking;
-        const contentBlock = output.content[idx] as ThinkingContent;
+        const contentBlock = output.content[contentIndex] as ThinkingContent;
         contentBlock.thinking = block.text;
 
         stream.push({
           type: "thinking_delta",
-          contentIndex: idx,
+          contentIndex,
           delta: event.delta!.thinking,
           partial: output,
         });
@@ -264,20 +276,21 @@ export function createEventBridge(
       if (idx === -1) return;
 
       const block = blocks[idx];
+      const contentIndex = block.contentIndex;
       if (block.type === "tool_use") {
         block.partialJson += event.delta!.partial_json;
 
         // Try to parse accumulated JSON -- on success update args, on failure keep previous
         try {
           block.arguments = JSON.parse(block.partialJson);
-          (output.content[idx] as any).arguments = block.arguments;
+          (output.content[contentIndex] as any).arguments = block.arguments;
         } catch {
           // Partial JSON not yet parseable -- keep previous arguments
         }
 
         stream.push({
           type: "toolcall_delta",
-          contentIndex: idx,
+          contentIndex,
           delta: event.delta!.partial_json,
           partial: output,
         });
@@ -291,8 +304,9 @@ export function createEventBridge(
       if (idx === -1) return;
 
       const block = blocks[idx];
+      const contentIndex = block.contentIndex;
       if (block.type === "thinking") {
-        const contentBlock = output.content[idx] as ThinkingContent;
+        const contentBlock = output.content[contentIndex] as ThinkingContent;
         contentBlock.thinkingSignature =
           (contentBlock.thinkingSignature || "") + event.delta!.signature;
       }
@@ -304,20 +318,21 @@ export function createEventBridge(
     if (idx === -1) return;
 
     const block = blocks[idx];
+    const contentIndex = block.contentIndex;
     // Clean up the tracking index from the block (no longer needed)
     delete (block as any).index;
 
     if (block.type === "text") {
       stream.push({
         type: "text_end",
-        contentIndex: idx,
+        contentIndex,
         content: block.text,
         partial: output,
       });
     } else if (block.type === "thinking") {
       stream.push({
         type: "thinking_end",
-        contentIndex: idx,
+        contentIndex,
         content: block.text,
         partial: output,
       });
@@ -332,7 +347,7 @@ export function createEventBridge(
       }
 
       // Update output.content with final arguments
-      const contentBlock = output.content[idx] as ToolCall;
+      const contentBlock = output.content[contentIndex] as ToolCall;
       (contentBlock as any).arguments = finalArgs;
 
       // ToolCall.arguments is typed as Record<string, any> in pi-ai, but we
@@ -347,7 +362,7 @@ export function createEventBridge(
 
       stream.push({
         type: "toolcall_end",
-        contentIndex: idx,
+        contentIndex,
         toolCall,
         partial: output,
       });
@@ -378,8 +393,59 @@ export function createEventBridge(
     // Pushing done here (synchronously) prevents pi from executing tools.
   }
 
+  function emitEphemeralStatus(text: string): void {
+    const trimmed = text.trim();
+    if (!trimmed || trimmed === lastEphemeralStatus) return;
+
+    if (!started) {
+      stream.push({ type: "start", partial: output });
+      started = true;
+    }
+
+    lastEphemeralStatus = trimmed;
+    const contentIndex = output.content.length;
+    const contentBlock = {
+      type: "text" as const,
+      text: trimmed,
+      __ephemeral: true,
+    };
+    (output.content as any).push(contentBlock);
+
+    stream.push({
+      type: "text_start",
+      contentIndex,
+      partial: output,
+    });
+    stream.push({
+      type: "text_delta",
+      contentIndex,
+      delta: trimmed,
+      partial: output,
+    });
+    stream.push({
+      type: "text_end",
+      contentIndex,
+      content: trimmed,
+      partial: output,
+    });
+  }
+
+  function getSanitizedOutput(): AssistantMessage {
+    return {
+      ...output,
+      content: output.content
+        .filter((block: any) => !block.__ephemeral)
+        .map((block: any) => {
+          const { __ephemeral, ...rest } = block;
+          return rest;
+        }),
+    };
+  }
+
   return {
     handleEvent,
+    emitEphemeralStatus,
     getOutput: () => output,
+    getFinalOutput: getSanitizedOutput,
   };
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -39,6 +39,7 @@ import { createEventBridge } from "./event-bridge.js";
 import { handleControlRequest } from "./control-handler.js";
 import { mapThinkingEffort } from "./thinking-config.js";
 import { isPiKnownClaudeTool } from "./tool-mapping.js";
+import { createSubAgentProgressTracker } from "./subagent-progress.js";
 /** Inactivity timeout: kill subprocess if no stdout for 180 seconds (3 minutes). */
 const INACTIVITY_TIMEOUT_MS = 180_000;
 const CONTEXT_LIMIT_ERROR_PATTERNS = [
@@ -163,6 +164,7 @@ export function streamViaCli(
 
       // Create event bridge (before endStreamWithError so bridge is in scope)
       const bridge = createEventBridge(stream, model);
+      const subAgentProgress = createSubAgentProgressTracker();
 
       // Guard against double stream.end() and double error events.
       // First error path wins; subsequent ones are no-ops.
@@ -180,7 +182,7 @@ export function streamViaCli(
       function endStreamWithError(errMsg: string) {
         if (streamEnded || broken) return;
         streamEnded = true;
-        const output = bridge.getOutput();
+        const output = bridge.getFinalOutput();
         const errorMessage = {
           ...output,
           content: output.content?.length
@@ -278,9 +280,17 @@ export function streamViaCli(
         if (!msg) return;
 
         if (msg.type === "stream_event") {
+          const progressText = subAgentProgress.handleEvent(
+            msg.event,
+            msg.parent_tool_use_id,
+          );
+          if (progressText) {
+            bridge.emitEphemeralStatus(progressText);
+          }
+
           // Only forward top-level events to pi's event bridge.
           // Sub-agent events (parent_tool_use_id !== null) are internal to the CLI.
-          const isTopLevel = !(msg as any).parent_tool_use_id;
+          const isTopLevel = !msg.parent_tool_use_id;
           if (isTopLevel) {
             bridge.handleEvent(msg.event);
           }
@@ -313,6 +323,11 @@ export function streamViaCli(
             rl.close();
             return; // Don't process further -- done event already pushed by event bridge
           }
+        } else if (msg.type === "system") {
+          const progressText = subAgentProgress.handleSystemMessage(msg);
+          if (progressText) {
+            bridge.emitEphemeralStatus(progressText);
+          }
         } else if (msg.type === "control_request") {
           handleControlRequest(msg, proc!.stdin!);
         } else if (msg.type === "result") {
@@ -343,7 +358,7 @@ export function streamViaCli(
       // inside handleMessageStop prevents pi from executing tools.
       // Guard with streamEnded to avoid pushing done after an error was already pushed.
       if (!streamEnded) {
-        const output = bridge.getOutput();
+        const output = bridge.getFinalOutput();
 
         // If stopReason is toolUse but there are no pi-known tool calls in content,
         // it means only user MCP tools were called (filtered by event bridge).

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -41,6 +41,38 @@ import { mapThinkingEffort } from "./thinking-config.js";
 import { isPiKnownClaudeTool } from "./tool-mapping.js";
 /** Inactivity timeout: kill subprocess if no stdout for 180 seconds (3 minutes). */
 const INACTIVITY_TIMEOUT_MS = 180_000;
+const CONTEXT_LIMIT_ERROR_PATTERNS = [
+  /prompt is too long/i,
+  /context(?: window| length)?(?: is)? too long/i,
+  /context(?: window| length)?.*(?:exceed|limit|maximum)/i,
+  /(?:prompt|input).*(?:exceed|limit).*(?:token|context)/i,
+  /too many tokens/i,
+];
+
+function trimErrorMessage(message?: string | null): string | undefined {
+  const trimmed = message?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function getContextLimitError(
+  ...messages: Array<string | undefined>
+): string | undefined {
+  for (const message of messages) {
+    const trimmed = trimErrorMessage(message);
+    if (!trimmed) continue;
+
+    const isContextLimit = CONTEXT_LIMIT_ERROR_PATTERNS.some((pattern) =>
+      pattern.test(trimmed),
+    );
+    if (!isContextLimit) continue;
+
+    return /^context too long:/i.test(trimmed)
+      ? trimmed
+      : `Context too long: ${trimmed}`;
+  }
+
+  return undefined;
+}
 
 /** Extended stream options: pi's SimpleStreamOptions plus optional cwd and mcpConfigPath */
 type StreamViaCLiOptions = SimpleStreamOptions & {
@@ -118,6 +150,13 @@ export function streamViaCli(
 
       // Register in global process registry for teardown cleanup
       registerProcess(proc);
+
+      proc.stdin?.on("error", (err: NodeJS.ErrnoException) => {
+        // Claude may close stdin early when it rejects an oversized prompt.
+        // Ignore EPIPE so stdout/result handling can surface the real error.
+        if (err.code === "EPIPE") return;
+        endStreamWithError(err.message);
+      });
 
       // Write user message to subprocess stdin
       writeUserMessage(proc, prompt);
@@ -201,7 +240,11 @@ export function streamViaCli(
       proc.on("error", (err: Error) => {
         if (broken) return; // Break-early killed the process intentionally
         const stderr = getStderr();
-        endStreamWithError(stderr || err.message);
+        endStreamWithError(
+          getContextLimitError(stderr, err.message) ||
+            trimErrorMessage(stderr) ||
+            err.message,
+        );
       });
 
       // Handle subprocess close -- surface crashes with stderr and exit code
@@ -210,9 +253,11 @@ export function streamViaCli(
         if (broken) return; // Break-early kill, expected
         if (code !== 0 && code !== null) {
           const stderr = getStderr();
-          const message = stderr
-            ? `Claude CLI exited with code ${code}: ${stderr.trim()}`
-            : `Claude CLI exited unexpectedly with code ${code}`;
+          const message =
+            getContextLimitError(stderr) ||
+            (stderr
+              ? `Claude CLI exited with code ${code}: ${stderr.trim()}`
+              : `Claude CLI exited unexpectedly with code ${code}`);
           endStreamWithError(message);
         }
       });
@@ -271,8 +316,16 @@ export function streamViaCli(
         } else if (msg.type === "control_request") {
           handleControlRequest(msg, proc!.stdin!);
         } else if (msg.type === "result") {
-          if (msg.subtype === "error") {
-            endStreamWithError(msg.error ?? "Unknown error from Claude CLI");
+          const cliReportedError = msg.subtype === "error" || msg.is_error;
+          if (cliReportedError) {
+            const stderr = getStderr();
+            endStreamWithError(
+              getContextLimitError(msg.error, msg.result, stderr) ||
+                trimErrorMessage(msg.error) ||
+                trimErrorMessage(msg.result) ||
+                trimErrorMessage(stderr) ||
+                "Unknown error from Claude CLI",
+            );
           }
           // For both success and error: clean up the subprocess
           clearTimeout(inactivityTimer);

--- a/src/subagent-progress.ts
+++ b/src/subagent-progress.ts
@@ -1,0 +1,218 @@
+import type { ClaudeApiEvent, ClaudeSystemMessage } from "./types.js";
+import { CUSTOM_TOOLS_MCP_PREFIX } from "./tool-mapping.js";
+
+interface OpenToolUseBlock {
+  parentToolUseId: string;
+  index: number;
+  id?: string;
+  name: string;
+  partialJson: string;
+}
+
+export interface SubAgentProgressTracker {
+  handleEvent(
+    event: ClaudeApiEvent,
+    parentToolUseId?: string | null,
+  ): string | null;
+  handleSystemMessage(message: ClaudeSystemMessage): string | null;
+}
+
+function parseArgs(partialJson: string): Record<string, unknown> {
+  if (!partialJson) return {};
+  try {
+    const parsed = JSON.parse(partialJson);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function truncate(value: string, max = 80): string {
+  return value.length > max ? `${value.slice(0, max - 3)}...` : value;
+}
+
+function firstStringArg(
+  args: Record<string, unknown>,
+  names: string[],
+): string | undefined {
+  for (const name of names) {
+    const value = args[name];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function formatToolName(toolName: string): string {
+  return toolName.startsWith(CUSTOM_TOOLS_MCP_PREFIX)
+    ? toolName.slice(CUSTOM_TOOLS_MCP_PREFIX.length)
+    : toolName;
+}
+
+function stripLeadingGerund(detail: string): string {
+  return detail.replace(
+    /^(reading|writing|editing|grepping|searching|running)\s+/i,
+    "",
+  );
+}
+
+function formatToolDetail(
+  toolName: string,
+  args: Record<string, unknown>,
+): string | undefined {
+  const normalizedName = toolName.toLowerCase();
+
+  if (
+    normalizedName === "read" ||
+    normalizedName === "write" ||
+    normalizedName === "edit"
+  ) {
+    return firstStringArg(args, ["file_path", "path"]);
+  }
+
+  if (normalizedName === "bash") {
+    return firstStringArg(args, ["command", "cmd"]);
+  }
+
+  if (normalizedName === "grep") {
+    const pattern = firstStringArg(args, ["pattern", "query"]);
+    const path = firstStringArg(args, ["path", "file_path"]);
+    if (pattern && path) return `${pattern} in ${path}`;
+    return pattern ?? path;
+  }
+
+  if (normalizedName === "glob") {
+    return firstStringArg(args, ["pattern", "path"]);
+  }
+
+  return firstStringArg(args, [
+    "description",
+    "task",
+    "prompt",
+    "goal",
+    "query",
+    "command",
+    "name",
+  ]);
+}
+
+export function createSubAgentProgressTracker(): SubAgentProgressTracker {
+  const openBlocks = new Map<string, OpenToolUseBlock>();
+  const toolNamesById = new Map<string, string>();
+
+  function getBlockKey(parentToolUseId: string, index: number): string {
+    return `${parentToolUseId}:${index}`;
+  }
+
+  function formatStatusLine(block: OpenToolUseBlock): string {
+    const parentLabel = toolNamesById.get(block.parentToolUseId) ?? "Sub-agent";
+    const toolLabel = formatToolName(block.name);
+    const args = parseArgs(block.partialJson);
+    const detail = formatToolDetail(block.name, args);
+
+    return detail
+      ? `${parentLabel}: running ${toolLabel} ${truncate(detail)}`
+      : `${parentLabel}: running ${toolLabel}`;
+  }
+
+  return {
+    handleEvent(event, parentToolUseId) {
+      if (
+        event.type === "content_block_start" &&
+        event.content_block?.type === "tool_use"
+      ) {
+        const toolId = event.content_block.id;
+        const toolName = event.content_block.name;
+
+        if (toolId && toolName) {
+          toolNamesById.set(toolId, toolName);
+        }
+
+        if (parentToolUseId && toolName) {
+          openBlocks.set(getBlockKey(parentToolUseId, event.index ?? 0), {
+            parentToolUseId,
+            index: event.index ?? 0,
+            id: toolId,
+            name: toolName,
+            partialJson: "",
+          });
+        }
+
+        return null;
+      }
+
+      if (!parentToolUseId) {
+        return null;
+      }
+
+      const key = getBlockKey(parentToolUseId, event.index ?? 0);
+      const block = openBlocks.get(key);
+      if (!block) {
+        return null;
+      }
+
+      if (
+        event.type === "content_block_delta" &&
+        event.delta?.type === "input_json_delta" &&
+        event.delta.partial_json != null
+      ) {
+        block.partialJson += event.delta.partial_json;
+        return null;
+      }
+
+      if (event.type === "content_block_stop") {
+        openBlocks.delete(key);
+        return formatStatusLine(block);
+      }
+
+      return null;
+    },
+    handleSystemMessage(message) {
+      const toolUseId = message.tool_use_id;
+      if (!toolUseId) return null;
+
+      const parentLabel = toolNamesById.get(toolUseId) ?? "Agent";
+
+      if (message.subtype === "task_started") {
+        const description = message.description?.trim();
+        return description
+          ? `${parentLabel}: started ${description}`
+          : `${parentLabel}: started`;
+      }
+
+      if (message.subtype === "task_progress") {
+        const toolLabel = message.last_tool_name
+          ? formatToolName(message.last_tool_name)
+          : undefined;
+        const description = message.description?.trim();
+
+        if (toolLabel && description) {
+          return `${parentLabel}: running ${toolLabel} ${truncate(stripLeadingGerund(description))}`;
+        }
+
+        if (toolLabel) {
+          return `${parentLabel}: running ${toolLabel}`;
+        }
+
+        if (description) {
+          return `${parentLabel}: ${truncate(description)}`;
+        }
+      }
+
+      if (
+        message.subtype === "task_notification" &&
+        message.status === "completed"
+      ) {
+        const summary = message.summary?.trim() || message.description?.trim();
+        return summary
+          ? `${parentLabel}: completed ${truncate(summary)}`
+          : `${parentLabel}: completed`;
+      }
+
+      return null;
+    },
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@
 export interface ClaudeStreamEventMessage {
   type: "stream_event";
   event: ClaudeApiEvent;
+  parent_tool_use_id?: string | null;
 }
 
 export interface ClaudeResultMessage {
@@ -22,6 +23,20 @@ export interface ClaudeSystemMessage {
   subtype: string;
   session_id?: string;
   tools?: unknown[];
+  tool_use_id?: string;
+  task_id?: string;
+  task_type?: string;
+  prompt?: string;
+  description?: string;
+  status?: string;
+  last_tool_name?: string;
+  output_file?: string;
+  summary?: string;
+  usage?: {
+    total_tokens?: number;
+    tool_uses?: number;
+    duration_ms?: number;
+  };
 }
 
 export interface ClaudeControlRequest {
@@ -84,4 +99,5 @@ export interface TrackedContentBlock {
   type: "text" | "thinking";
   text: string;
   index: number; // Claude's content_block index
+  contentIndex: number; // Position in output.content
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,8 @@ export interface ClaudeResultMessage {
   subtype: "success" | "error";
   result?: string;
   error?: string;
+  is_error?: boolean;
+  stop_reason?: string;
   session_id?: string;
 }
 

--- a/tests/event-bridge.test.ts
+++ b/tests/event-bridge.test.ts
@@ -225,6 +225,32 @@ describe("createEventBridge", () => {
     });
   });
 
+  describe("ephemeral status streaming", () => {
+    it("streams temporary status text without keeping it in the final output", () => {
+      const bridge = createBridgeWithStart();
+
+      bridge.emitEphemeralStatus("Agent: running Read src/provider.ts");
+
+      expect(stream.push).toHaveBeenCalledTimes(3);
+      expect(stream.events[0]).toMatchObject({
+        type: "text_start",
+        contentIndex: 0,
+      });
+      expect(stream.events[1]).toMatchObject({
+        type: "text_delta",
+        contentIndex: 0,
+        delta: "Agent: running Read src/provider.ts",
+      });
+      expect(stream.events[2]).toMatchObject({
+        type: "text_end",
+        contentIndex: 0,
+        content: "Agent: running Read src/provider.ts",
+      });
+
+      expect(bridge.getFinalOutput().content).toEqual([]);
+    });
+  });
+
   describe("message_delta handling", () => {
     it("captures stop_reason from message_delta", () => {
       const bridge = createEventBridge(stream as any, model as any);

--- a/tests/provider.test.ts
+++ b/tests/provider.test.ts
@@ -6,7 +6,10 @@ import { PassThrough } from "node:stream";
 vi.mock("cross-spawn", () => ({
   default: vi.fn(() => {
     const proc = new EventEmitter();
-    const stdin = { write: vi.fn(), end: vi.fn() };
+    const stdin = Object.assign(new EventEmitter(), {
+      write: vi.fn(),
+      end: vi.fn(),
+    });
     const stdout = new PassThrough();
     const stderr = new EventEmitter();
     (proc as any).stdin = stdin;
@@ -287,6 +290,93 @@ describe("streamViaCli", () => {
     expect(doneEvent).toBeDefined();
     expect(doneEvent.message.content).toBeDefined();
     expect(mockStream.end).toHaveBeenCalled();
+  });
+
+  it("normalizes context limit result errors into a clear message", async () => {
+    const model = mockModels[0] as any;
+    const context = {
+      messages: [{ role: "user", content: "Hello" }],
+    };
+
+    streamViaCli(model, context);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const proc = (spawn as any).mock.results[0].value;
+    proc.stdout.write(
+      JSON.stringify({
+        type: "result",
+        subtype: "error",
+        error: "Prompt is too long for this model",
+      }) + "\n",
+    );
+    proc.stdout.end();
+    await vi.advanceTimersByTimeAsync(100);
+
+    const mockStream = MockAssistantMessageEventStream.mock.instances[0];
+    const doneEvent = mockStream._events.find((e: any) => e.type === "done");
+    expect(doneEvent).toBeDefined();
+    expect(doneEvent.message.content[0].text).toContain("Context too long:");
+    expect(doneEvent.message.content[0].text).toContain(
+      "Prompt is too long for this model",
+    );
+  });
+
+  it("treats Claude CLI success results marked is_error as failures", async () => {
+    const model = mockModels[0] as any;
+    const context = {
+      messages: [{ role: "user", content: "Hello" }],
+    };
+
+    streamViaCli(model, context);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const proc = (spawn as any).mock.results[0].value;
+    proc.stdout.write(
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: true,
+        result: "Prompt is too long",
+      }) + "\n",
+    );
+    proc.stdout.end();
+    await vi.advanceTimersByTimeAsync(100);
+
+    const mockStream = MockAssistantMessageEventStream.mock.instances[0];
+    const doneEvent = mockStream._events.find((e: any) => e.type === "done");
+    expect(doneEvent).toBeDefined();
+    expect(doneEvent.message.content[0].text).toContain("Context too long:");
+    expect(doneEvent.message.content[0].text).toContain("Prompt is too long");
+  });
+
+  it("ignores stdin EPIPE so the real CLI error can still surface", async () => {
+    const model = mockModels[0] as any;
+    const context = {
+      messages: [{ role: "user", content: "Hello" }],
+    };
+
+    streamViaCli(model, context);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const proc = (spawn as any).mock.results[0].value;
+    proc.stdin.emit("error", Object.assign(new Error("write EPIPE"), {
+      code: "EPIPE",
+    }));
+    proc.stdout.write(
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: true,
+        result: "Prompt is too long",
+      }) + "\n",
+    );
+    proc.stdout.end();
+    await vi.advanceTimersByTimeAsync(100);
+
+    const mockStream = MockAssistantMessageEventStream.mock.instances[0];
+    const doneEvent = mockStream._events.find((e: any) => e.type === "done");
+    expect(doneEvent).toBeDefined();
+    expect(doneEvent.message.content[0].text).toContain("Context too long:");
   });
 
   it("calls cleanupProcess after receiving result", async () => {
@@ -1181,6 +1271,33 @@ describe("streamViaCli", () => {
       );
       expect(doneEvent).toBeDefined();
       expect(doneEvent.message.content).toBeDefined();
+    });
+
+    it("surfaces context limit crashes without wrapping them as generic exit-code failures", async () => {
+      const model = mockModels[0] as any;
+      const context = {
+        messages: [{ role: "user", content: "Hello" }],
+      };
+
+      streamViaCli(model, context);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const proc = (spawn as any).mock.results[0].value;
+      proc.stderr.emit(
+        "data",
+        Buffer.from("Prompt is too long for this model"),
+      );
+      proc.emit("close", 1, null);
+      proc.stdout.end();
+      await vi.advanceTimersByTimeAsync(100);
+
+      const mockStream = MockAssistantMessageEventStream.mock.instances[0];
+      const doneEvent = mockStream._events.find((e: any) => e.type === "done");
+      expect(doneEvent).toBeDefined();
+      expect(doneEvent.message.content[0].text).toContain("Context too long:");
+      expect(doneEvent.message.content[0].text).not.toContain(
+        "exited with code 1",
+      );
     });
 
     it("does not push error on normal close (code 0)", async () => {

--- a/tests/provider.test.ts
+++ b/tests/provider.test.ts
@@ -359,9 +359,12 @@ describe("streamViaCli", () => {
     await vi.advanceTimersByTimeAsync(0);
 
     const proc = (spawn as any).mock.results[0].value;
-    proc.stdin.emit("error", Object.assign(new Error("write EPIPE"), {
-      code: "EPIPE",
-    }));
+    proc.stdin.emit(
+      "error",
+      Object.assign(new Error("write EPIPE"), {
+        code: "EPIPE",
+      }),
+    );
     proc.stdout.write(
       JSON.stringify({
         type: "result",

--- a/tests/provider.test.ts
+++ b/tests/provider.test.ts
@@ -1126,6 +1126,306 @@ describe("streamViaCli", () => {
       vi.advanceTimersByTime(500);
     });
 
+    it("surfaces sub-agent tool progress without polluting the final assistant message", async () => {
+      const model = mockModels[0] as any;
+      const context = {
+        messages: [{ role: "user", content: "Run an agent" }],
+      };
+
+      streamViaCli(model, context);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const proc = (spawn as any).mock.results[0].value;
+
+      const lines = [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "message_start",
+            message: { usage: { input_tokens: 10, output_tokens: 0 } },
+          },
+          parent_tool_use_id: null,
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: {
+              type: "tool_use",
+              id: "agent_1",
+              name: "Agent",
+            },
+          },
+          parent_tool_use_id: null,
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop", index: 0 },
+          parent_tool_use_id: null,
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "message_delta",
+            delta: { stop_reason: "tool_use" },
+            usage: { output_tokens: 5 },
+          },
+          parent_tool_use_id: null,
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "message_stop" },
+          parent_tool_use_id: null,
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: {
+              type: "tool_use",
+              id: "read_1",
+              name: "Read",
+            },
+          },
+          parent_tool_use_id: "agent_1",
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: {
+              type: "input_json_delta",
+              partial_json: '{"file_path":"src/provider.ts"}',
+            },
+          },
+          parent_tool_use_id: "agent_1",
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop", index: 0 },
+          parent_tool_use_id: "agent_1",
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "message_start",
+            message: { usage: { input_tokens: 20, output_tokens: 0 } },
+          },
+          parent_tool_use_id: null,
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "text", text: "" },
+          },
+          parent_tool_use_id: null,
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: { type: "text_delta", text: "Agent found the code." },
+          },
+          parent_tool_use_id: null,
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop", index: 0 },
+          parent_tool_use_id: null,
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "message_delta",
+            delta: { stop_reason: "end_turn" },
+            usage: { output_tokens: 10 },
+          },
+          parent_tool_use_id: null,
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "message_stop" },
+          parent_tool_use_id: null,
+        }),
+        JSON.stringify({
+          type: "result",
+          subtype: "success",
+          result: "Agent found the code.",
+        }),
+      ];
+
+      for (const line of lines) {
+        proc.stdout.write(line + "\n");
+      }
+      proc.stdout.end();
+      await vi.advanceTimersByTimeAsync(100);
+
+      const mockStream = MockAssistantMessageEventStream.mock.instances[0];
+      const progressEvent = mockStream._events.find(
+        (e: any) =>
+          e.type === "text_delta" &&
+          e.delta === "Agent: running Read src/provider.ts",
+      );
+      expect(progressEvent).toBeDefined();
+
+      const doneEvent = mockStream._events.find((e: any) => e.type === "done");
+      expect(doneEvent).toBeDefined();
+      expect(doneEvent.message.content).toEqual([
+        { type: "text", text: "Agent found the code." },
+      ]);
+    });
+
+    it("surfaces real Claude task_progress system messages for Agent runs", async () => {
+      const model = mockModels[0] as any;
+      const context = {
+        messages: [{ role: "user", content: "Run an agent" }],
+      };
+
+      streamViaCli(model, context);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const proc = (spawn as any).mock.results[0].value;
+
+      const lines = [
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "message_start",
+            message: { usage: { input_tokens: 10, output_tokens: 0 } },
+          },
+          parent_tool_use_id: null,
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: {
+              type: "tool_use",
+              id: "agent_1",
+              name: "Agent",
+            },
+          },
+          parent_tool_use_id: null,
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop", index: 0 },
+          parent_tool_use_id: null,
+        }),
+        JSON.stringify({
+          type: "system",
+          subtype: "task_started",
+          tool_use_id: "agent_1",
+          description: "Find INACTIVITY_TIMEOUT_MS value",
+        }),
+        JSON.stringify({
+          type: "system",
+          subtype: "task_progress",
+          tool_use_id: "agent_1",
+          description: "Reading src/provider.ts",
+          last_tool_name: "Read",
+        }),
+        JSON.stringify({
+          type: "system",
+          subtype: "task_notification",
+          tool_use_id: "agent_1",
+          status: "completed",
+          summary: "Find INACTIVITY_TIMEOUT_MS value",
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "message_start",
+            message: { usage: { input_tokens: 20, output_tokens: 0 } },
+          },
+          parent_tool_use_id: null,
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_start",
+            index: 0,
+            content_block: { type: "text", text: "" },
+          },
+          parent_tool_use_id: null,
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "content_block_delta",
+            index: 0,
+            delta: {
+              type: "text_delta",
+              text: "The agent found that INACTIVITY_TIMEOUT_MS is 180_000.",
+            },
+          },
+          parent_tool_use_id: null,
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "content_block_stop", index: 0 },
+          parent_tool_use_id: null,
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: {
+            type: "message_delta",
+            delta: { stop_reason: "end_turn" },
+            usage: { output_tokens: 10 },
+          },
+          parent_tool_use_id: null,
+        }),
+        JSON.stringify({
+          type: "stream_event",
+          event: { type: "message_stop" },
+          parent_tool_use_id: null,
+        }),
+        JSON.stringify({
+          type: "result",
+          subtype: "success",
+          result: "The agent found that INACTIVITY_TIMEOUT_MS is 180_000.",
+        }),
+      ];
+
+      for (const line of lines) {
+        proc.stdout.write(line + "\n");
+      }
+      proc.stdout.end();
+      await vi.advanceTimersByTimeAsync(100);
+
+      const mockStream = MockAssistantMessageEventStream.mock.instances[0];
+      expect(
+        mockStream._events.find(
+          (e: any) =>
+            e.type === "text_delta" &&
+            e.delta === "Agent: running Read src/provider.ts",
+        ),
+      ).toBeDefined();
+
+      expect(
+        mockStream._events.find(
+          (e: any) =>
+            e.type === "text_delta" &&
+            e.delta === "Agent: started Find INACTIVITY_TIMEOUT_MS value",
+        ),
+      ).toBeDefined();
+
+      const doneEvent = mockStream._events.find((e: any) => e.type === "done");
+      expect(doneEvent.message.content).toEqual([
+        {
+          type: "text",
+          text: "The agent found that INACTIVITY_TIMEOUT_MS is 180_000.",
+        },
+      ]);
+    });
+
     it("does NOT break-early when only user MCP tools are seen (not custom-tools)", async () => {
       const model = mockModels[0] as any;
       const context = {

--- a/tests/subagent-progress.test.ts
+++ b/tests/subagent-progress.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+import type { ClaudeApiEvent, ClaudeSystemMessage } from "../src/types.js";
+import { CUSTOM_TOOLS_MCP_PREFIX } from "../src/tool-mapping.js";
+import { createSubAgentProgressTracker } from "../src/subagent-progress.js";
+
+const parentToolUseId = "parent-tool";
+
+function startParentEvent(
+  tracker: ReturnType<typeof createSubAgentProgressTracker>,
+) {
+  tracker.handleEvent({
+    type: "content_block_start",
+    index: 0,
+    content_block: {
+      type: "tool_use",
+      id: parentToolUseId,
+      name: "Parent Agent",
+    },
+  });
+}
+
+function createToolUseStart(
+  id: string,
+  name: string,
+  index = 0,
+): ClaudeApiEvent {
+  return {
+    type: "content_block_start",
+    index,
+    content_block: {
+      type: "tool_use",
+      id,
+      name,
+    },
+  };
+}
+
+function createDelta(partialJson: string, index = 0): ClaudeApiEvent {
+  return {
+    type: "content_block_delta",
+    index,
+    delta: {
+      type: "input_json_delta",
+      partial_json: partialJson,
+    },
+  };
+}
+
+function createStop(index = 0): ClaudeApiEvent {
+  return {
+    type: "content_block_stop",
+    index,
+  };
+}
+
+describe("SubAgentProgressTracker - tool events", () => {
+  it("formats status lines with parsed args", () => {
+    const tracker = createSubAgentProgressTracker();
+    startParentEvent(tracker);
+
+    tracker.handleEvent(
+      createToolUseStart("child-tool", "read"),
+      parentToolUseId,
+    );
+    tracker.handleEvent(
+      createDelta('{"file_path":"examples/config.json"}'),
+      parentToolUseId,
+    );
+    const status = tracker.handleEvent(createStop(), parentToolUseId);
+
+    expect(status).toBe("Parent Agent: running read examples/config.json");
+  });
+
+  it("ignores invalid JSON in partial args", () => {
+    const tracker = createSubAgentProgressTracker();
+    startParentEvent(tracker);
+
+    tracker.handleEvent(
+      createToolUseStart("child-tool", "read"),
+      parentToolUseId,
+    );
+    tracker.handleEvent(createDelta("{bad"), parentToolUseId);
+    const status = tracker.handleEvent(createStop(), parentToolUseId);
+
+    expect(status).toBe("Parent Agent: running read");
+  });
+
+  it("strips MCP prefixes and falls back to description args", () => {
+    const tracker = createSubAgentProgressTracker();
+    startParentEvent(tracker);
+
+    tracker.handleEvent(
+      createToolUseStart("child-tool", `${CUSTOM_TOOLS_MCP_PREFIX}deploy`),
+      parentToolUseId,
+    );
+    tracker.handleEvent(
+      createDelta('{"description":"Deploy changes"}'),
+      parentToolUseId,
+    );
+    const status = tracker.handleEvent(createStop(), parentToolUseId);
+
+    expect(status).toBe("Parent Agent: running deploy Deploy changes");
+  });
+});
+
+describe("SubAgentProgressTracker - system messages", () => {
+  it("handles task_started, task_progress, and notifications", () => {
+    const tracker = createSubAgentProgressTracker();
+    startParentEvent(tracker);
+
+    const started = tracker.handleSystemMessage({
+      type: "system",
+      subtype: "task_started",
+      tool_use_id: parentToolUseId,
+      description: "  prepping work  ",
+    });
+    expect(started).toBe("Parent Agent: started prepping work");
+
+    const progressTool = tracker.handleSystemMessage({
+      type: "system",
+      subtype: "task_progress",
+      tool_use_id: parentToolUseId,
+      last_tool_name: "Read",
+      description: "running read file",
+    });
+    expect(progressTool).toBe("Parent Agent: running Read read file");
+
+    const progressNoTool = tracker.handleSystemMessage({
+      type: "system",
+      subtype: "task_progress",
+      tool_use_id: parentToolUseId,
+      description: "Ongoing check",
+    });
+    expect(progressNoTool).toBe("Parent Agent: Ongoing check");
+
+    const completedSummary = tracker.handleSystemMessage({
+      type: "system",
+      subtype: "task_notification",
+      tool_use_id: parentToolUseId,
+      status: "completed",
+      summary: "All done",
+    });
+    expect(completedSummary).toBe("Parent Agent: completed All done");
+
+    const completedDescription = tracker.handleSystemMessage({
+      type: "system",
+      subtype: "task_notification",
+      tool_use_id: parentToolUseId,
+      status: "completed",
+      summary: "  ",
+      description: "Wrapped up",
+    });
+    expect(completedDescription).toBe("Parent Agent: completed Wrapped up");
+
+    const completedPlain = tracker.handleSystemMessage({
+      type: "system",
+      subtype: "task_notification",
+      tool_use_id: parentToolUseId,
+      status: "completed",
+    });
+    expect(completedPlain).toBe("Parent Agent: completed");
+  });
+
+  it("returns null when no tool_use_id is provided", () => {
+    const tracker = createSubAgentProgressTracker();
+
+    const result = tracker.handleSystemMessage({
+      type: "system",
+      subtype: "task_started",
+    } as ClaudeSystemMessage);
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- pass through Claude CLI context-limit failures with a clear error instead of a generic subprocess failure
- handle the real Claude CLI `result` packet shape where `is_error: true` can arrive with `subtype: "success"`
- ignore early stdin `EPIPE` on oversized first-turn prompts so stdout can surface the actual failure
- add vanilla `pi install npm:pi-claude-cli` instructions to the README

## Verification
- npm test
- npm run typecheck
- live Claude CLI context-limit check against an oversized prompt