### PR TITLE
fix: tool continuation after early break

### DIFF
--- a/src/prompt-builder.ts
+++ b/src/prompt-builder.ts
@@ -29,6 +29,15 @@ type AnthropicContentBlock =
       source: { type: "base64"; media_type: string; data: string };
     };
 
+type ClaudeToolResultBlock = {
+  type: "tool_result";
+  tool_use_id?: string;
+  content: string | AnthropicContentBlock[];
+  is_error?: boolean;
+};
+
+type ClaudeResumeBlock = AnthropicContentBlock | ClaudeToolResultBlock;
+
 // We use `any` for Context to avoid requiring @mariozechner/pi-ai at dev time.
 // At runtime, pi provides the real Context type.
 
@@ -138,77 +147,175 @@ function buildCustomToolResultPrompt(messages: any[]): string | null {
 }
 
 /**
- * Build a prompt for a resumed session.
- *
- * When resuming via --resume, the CLI already has the full conversation history.
- * We only need to send the new content since the last turn: the last assistant
- * response's tool results (if any) followed by the latest user message.
- *
- * For tool_use flows: pi sends [user, assistant(toolCall), toolResult, ...]
- * We need to include tool results so the resumed session sees them, plus the
- * final user message.
- *
- * Falls back to full prompt if the message structure is unexpected.
+ * Find the contiguous trailing toolResult block that ends at endExclusive.
  */
-export function buildResumePrompt(context: {
-  messages: any[];
-}): string | AnthropicContentBlock[] {
-  const messages = context.messages;
-  if (messages.length === 0) return "";
-
-  // Find the last user message
-  const finalUserIndex = findFinalUserMessageIndex(messages);
-  if (finalUserIndex < 0) return "";
-
-  // Collect new messages: everything from the last assistant turn onwards
-  // (tool results from the last assistant + the new user message)
-  const newMessages: any[] = [];
-
-  // Walk backwards from finalUserIndex to find where new content starts.
-  // Include trailing toolResult messages that follow the last assistant turn.
-  let startIdx = finalUserIndex;
-  for (let i = finalUserIndex - 1; i >= 0; i--) {
+function findTrailingToolResults(
+  messages: any[],
+  endExclusive: number,
+): { start: number; results: any[] } | null {
+  let start = endExclusive;
+  for (let i = endExclusive - 1; i >= 0; i--) {
     if (messages[i].role === "toolResult") {
-      startIdx = i;
+      start = i;
     } else {
       break;
     }
   }
 
-  for (let i = startIdx; i < messages.length; i++) {
-    newMessages.push(messages[i]);
+  if (start === endExclusive) return null;
+  return {
+    start,
+    results: messages.slice(start, endExclusive),
+  };
+}
+
+/**
+ * Extract toolCall blocks from an assistant message.
+ */
+function getAssistantToolCalls(message: any): any[] {
+  if (message?.role !== "assistant" || !Array.isArray(message.content)) {
+    return [];
+  }
+  return message.content.filter((block: any) => block.type === "toolCall");
+}
+
+/**
+ * Check whether a contiguous trailing toolResult block fully satisfies the
+ * immediately preceding assistant tool-call batch.
+ *
+ * Uses toolCallId matching when available; otherwise falls back to count.
+ */
+function hasCompleteToolResultBatch(
+  messages: any[],
+  toolResultStart: number,
+  toolResultEndExclusive: number,
+): boolean {
+  if (toolResultStart <= 0) return false;
+
+  const toolCalls = getAssistantToolCalls(messages[toolResultStart - 1]);
+  const toolResults = messages.slice(toolResultStart, toolResultEndExclusive);
+
+  if (toolCalls.length === 0) return false;
+  if (toolResults.length !== toolCalls.length) return false;
+
+  const expectedIds = toolCalls
+    .map((toolCall: any) => toolCall.id)
+    .filter((id: any) => typeof id === "string");
+  const resultIds = toolResults
+    .map((toolResult: any) => toolResult.toolCallId)
+    .filter((id: any) => typeof id === "string");
+
+  if (expectedIds.length === toolCalls.length && resultIds.length === toolResults.length) {
+    const resultIdSet = new Set(resultIds);
+    return (
+      resultIdSet.size === expectedIds.length &&
+      expectedIds.every((id: string) => resultIdSet.has(id))
+    );
   }
 
-  // If there are only tool results + one user message, build a combined prompt
-  const parts: string[] = [];
-  for (const msg of newMessages) {
-    if (msg.role === "toolResult") {
-      if (msg.toolName && isCustomToolName(msg.toolName)) {
-        parts.push(`TOOL RESULT (${msg.toolName}):`);
+  return true;
+}
+
+/**
+ * Append a tool result message to resume prompt text parts.
+ */
+function buildToolResultContent(
+  content: string | any[],
+): string | AnthropicContentBlock[] {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+
+  const hasImages = content.some((block) => block.type === "image");
+  if (!hasImages) {
+    return toolResultContentToText(content);
+  }
+
+  const blocks: AnthropicContentBlock[] = [];
+  for (const block of content) {
+    if (block.type === "text") {
+      blocks.push({ type: "text", text: block.text ?? "" });
+    } else if (block.type === "image") {
+      const translated = translateImageBlock(block);
+      if (translated) {
+        blocks.push(translated);
       } else {
-        const claudeToolName = msg.toolName
-          ? mapPiToolNameToClaude(msg.toolName)
-          : "unknown";
-        parts.push(`TOOL RESULT (historical ${claudeToolName}):`);
+        blocks.push({
+          type: "text",
+          text: "[An image was shared here but could not be included]",
+        });
+        placeholderImageCount++;
       }
-      parts.push(toolResultContentToText(msg.content));
-    } else if (msg.role === "user") {
-      // Check for images in the final user message
-      if (contentHasImages(msg.content)) {
-        const textSoFar = parts.join("\n");
-        const userContent = buildFinalUserContent(msg.content);
-        const result: AnthropicContentBlock[] = [];
-        if (textSoFar) {
-          result.push({ type: "text", text: textSoFar });
-        }
-        result.push(...userContent);
-        return result;
-      }
-      parts.push(userContentToText(msg.content));
     }
   }
 
-  return parts.join("\n") || "";
+  if (!blocks.some((block) => block.type === "text")) {
+    blocks.unshift({ type: "text", text: "(see attached image)" });
+  }
+
+  return blocks;
+}
+
+function buildToolResultBlock(msg: any): ClaudeToolResultBlock {
+  return {
+    type: "tool_result",
+    tool_use_id: msg.toolCallId,
+    content: buildToolResultContent(msg.content),
+    is_error: msg.isError,
+  };
+}
+
+/**
+ * Build a prompt for a resumed session.
+ *
+ * When resuming via --resume, the CLI already has the full conversation history.
+ * We only send new input since the last assistant turn:
+ * - trailing tool results alone, or
+ * - trailing tool results followed by the latest user message, or
+ * - just the latest user message.
+ *
+ * If the conversation ends with an incomplete parallel tool-result batch,
+ * returns an empty string so the caller can avoid resuming prematurely.
+ */
+export function buildResumePrompt(context: {
+  messages: any[];
+}): string | ClaudeResumeBlock[] {
+  const messages = context.messages;
+  if (messages.length === 0) return "";
+
+  const last = messages[messages.length - 1];
+  const finalUser = last?.role === "user" ? last : null;
+  const toolResultsEndExclusive = finalUser ? messages.length - 1 : messages.length;
+  const trailingToolResults = findTrailingToolResults(messages, toolResultsEndExclusive);
+
+  const blocks: ClaudeResumeBlock[] = [];
+
+  if (trailingToolResults) {
+    if (
+      !hasCompleteToolResultBatch(
+        messages,
+        trailingToolResults.start,
+        toolResultsEndExclusive,
+      )
+    ) {
+      return "";
+    }
+
+    for (const msg of trailingToolResults.results) {
+      blocks.push(buildToolResultBlock(msg));
+    }
+  }
+
+  if (!finalUser) {
+    return blocks.length > 0 ? blocks : "";
+  }
+
+  if (contentHasImages(finalUser.content)) {
+    blocks.push(...buildFinalUserContent(finalUser.content));
+    return blocks;
+  }
+
+  blocks.push({ type: "text", text: userContentToText(finalUser.content) });
+  return blocks;
 }
 
 export function buildPrompt(context: {

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -15,6 +15,7 @@
  */
 
 import { createInterface } from "node:readline";
+import { appendFileSync } from "node:fs";
 import {
   AssistantMessageEventStream,
   type Model,
@@ -41,6 +42,14 @@ import { mapThinkingEffort } from "./thinking-config.js";
 import { isPiKnownClaudeTool } from "./tool-mapping.js";
 /** Inactivity timeout: kill subprocess if no stdout for 180 seconds (3 minutes). */
 const INACTIVITY_TIMEOUT_MS = 180_000;
+const DEBUG_LOG = "/tmp/pi-claude-cli-debug.log";
+
+function debugLog(label: string, data?: any) {
+  try {
+    const line = `[${new Date().toISOString()}] ${label}${data === undefined ? "" : ` ${JSON.stringify(data)}`}\n`;
+    appendFileSync(DEBUG_LOG, line);
+  } catch {}
+}
 
 /** Extended stream options: pi's SimpleStreamOptions plus optional cwd and mcpConfigPath */
 type StreamViaCLiOptions = SimpleStreamOptions & {
@@ -81,19 +90,37 @@ export function streamViaCli(
     try {
       const cwd = options?.cwd ?? process.cwd();
 
-      // Resume if pi provides a session ID AND this isn't the first turn.
-      // Pi passes sessionId on every call (including first), but we can only
-      // --resume a CLI session that already exists on disk from a prior turn.
+      const hasToolResults = context.messages.some(
+        (m: any) => m.role === "toolResult",
+      );
+
+      // IMPORTANT: a tool_use turn is interrupted early via SIGKILL so Claude
+      // often hasn't persisted a resumable session yet. Resuming such a turn
+      // fails with "No conversation found with session ID". For any context
+      // involving tool results, fall back to full-history replay instead of
+      // --resume/--session-id.
       const resumeSessionId =
-        options?.sessionId && context.messages.length > 1
+        options?.sessionId && context.messages.length > 1 && !hasToolResults
+          ? options.sessionId
+          : undefined;
+      const newSessionId =
+        options?.sessionId && context.messages.length === 1 && !hasToolResults
           ? options.sessionId
           : undefined;
 
       // Build prompt: if resuming, only send the latest user turn;
-      // otherwise build the full flattened conversation history
+      // otherwise build the full flattened conversation history.
       const prompt = resumeSessionId
         ? buildResumePrompt(context)
         : buildPrompt(context);
+      debugLog("start", {
+        sessionId: (options as any)?.sessionId,
+        resumeSessionId,
+        newSessionId,
+        hasToolResults,
+        messageCount: context.messages.length,
+        promptKind: Array.isArray(prompt) ? "array" : typeof prompt,
+      });
       const systemPrompt = resumeSessionId
         ? undefined
         : buildSystemPrompt(context, cwd);
@@ -112,9 +139,10 @@ export function streamViaCli(
         effort,
         mcpConfigPath: options?.mcpConfigPath,
         resumeSessionId,
-        newSessionId: !resumeSessionId ? options?.sessionId : undefined,
+        newSessionId,
       });
       const getStderr = captureStderr(proc);
+      debugLog("spawned", { pid: proc.pid, resumeSessionId, newSessionId });
 
       // Register in global process registry for teardown cleanup
       registerProcess(proc);
@@ -128,6 +156,9 @@ export function streamViaCli(
       // Guard against double stream.end() and double error events.
       // First error path wins; subsequent ones are no-ops.
       let streamEnded = false;
+      // Claude CLI sometimes emits only a final {type:"result", result:"..."}
+      // without streaming text blocks first. Preserve that text as a fallback.
+      let resultTextFallback: string | undefined;
 
       /**
        * End the stream with an error, using a "done" event instead of "error".
@@ -231,6 +262,7 @@ export function streamViaCli(
 
         const msg = parseLine(line);
         if (!msg) return;
+        debugLog("msg", { type: (msg as any).type, subtype: (msg as any).subtype, eventType: (msg as any).event?.type });
 
         if (msg.type === "stream_event") {
           // Only forward top-level events to pi's event bridge.
@@ -264,6 +296,7 @@ export function streamViaCli(
             broken = true; // Set guard BEFORE rl.close() to prevent buffered lines
             clearTimeout(inactivityTimer);
             // Pi will execute these tools. Kill subprocess to prevent CLI from executing them.
+            debugLog("break-early", { pid: proc?.pid });
             forceKillProcess(proc!);
             rl.close();
             return; // Don't process further -- done event already pushed by event bridge
@@ -272,7 +305,11 @@ export function streamViaCli(
           handleControlRequest(msg, proc!.stdin!);
         } else if (msg.type === "result") {
           if (msg.subtype === "error") {
+            debugLog("result-error", msg);
             endStreamWithError(msg.error ?? "Unknown error from Claude CLI");
+          } else if (msg.subtype === "success" && msg.result) {
+            debugLog("result-success", { result: msg.result, session_id: (msg as any).session_id });
+            resultTextFallback = msg.result;
           }
           // For both success and error: clean up the subprocess
           clearTimeout(inactivityTimer);
@@ -292,6 +329,13 @@ export function streamViaCli(
       if (!streamEnded) {
         const output = bridge.getOutput();
 
+        if (
+          resultTextFallback &&
+          (!output.content || output.content.length === 0)
+        ) {
+          output.content = [{ type: "text", text: resultTextFallback }] as any;
+        }
+
         // If stopReason is toolUse but there are no pi-known tool calls in content,
         // it means only user MCP tools were called (filtered by event bridge).
         // Override to "stop" so pi doesn't try to execute non-existent tools.
@@ -304,6 +348,7 @@ export function streamViaCli(
             : output.stopReason;
 
         streamEnded = true;
+        debugLog("done", { effectiveReason, contentTypes: (output.content || []).map((c: any) => c.type) });
         stream.push({
           type: "done",
           reason:

--- a/tests/prompt-builder.test.ts
+++ b/tests/prompt-builder.test.ts
@@ -921,7 +921,9 @@ describe("buildResumePrompt", () => {
     const context = {
       messages: [{ role: "user", content: "Hello world" }],
     };
-    expect(buildResumePrompt(context)).toBe("Hello world");
+    expect(buildResumePrompt(context)).toEqual([
+      { type: "text", text: "Hello world" },
+    ]);
   });
 
   it("extracts only the last user message from a multi-turn conversation", () => {
@@ -932,7 +934,9 @@ describe("buildResumePrompt", () => {
         { role: "user", content: "Follow-up question" },
       ],
     };
-    expect(buildResumePrompt(context)).toBe("Follow-up question");
+    expect(buildResumePrompt(context)).toEqual([
+      { type: "text", text: "Follow-up question" },
+    ]);
   });
 
   it("includes tool results preceding the final user message", () => {
@@ -957,10 +961,16 @@ describe("buildResumePrompt", () => {
         { role: "user", content: "Now explain it" },
       ],
     };
-    const result = buildResumePrompt(context) as string;
-    expect(result).toContain("TOOL RESULT (historical Read):");
-    expect(result).toContain("file contents here");
-    expect(result).toContain("Now explain it");
+    const result = buildResumePrompt(context) as any[];
+    expect(result).toEqual([
+      {
+        type: "tool_result",
+        tool_use_id: undefined,
+        content: "file contents here",
+        is_error: undefined,
+      },
+      { type: "text", text: "Now explain it" },
+    ]);
   });
 
   it("includes multiple tool results preceding the final user message", () => {
@@ -995,10 +1005,22 @@ describe("buildResumePrompt", () => {
         { role: "user", content: "Compare them" },
       ],
     };
-    const result = buildResumePrompt(context) as string;
-    expect(result).toContain("contents of a");
-    expect(result).toContain("contents of b");
-    expect(result).toContain("Compare them");
+    const result = buildResumePrompt(context) as any[];
+    expect(result).toEqual([
+      {
+        type: "tool_result",
+        tool_use_id: undefined,
+        content: "contents of a",
+        is_error: undefined,
+      },
+      {
+        type: "tool_result",
+        tool_use_id: undefined,
+        content: "contents of b",
+        is_error: undefined,
+      },
+      { type: "text", text: "Compare them" },
+    ]);
   });
 
   it("handles custom tool results with plain name format", () => {
@@ -1017,13 +1039,141 @@ describe("buildResumePrompt", () => {
         { role: "user", content: "Check status" },
       ],
     };
-    const result = buildResumePrompt(context) as string;
-    expect(result).toContain("TOOL RESULT (deploy):");
-    expect(result).toContain("Deployed successfully");
-    expect(result).toContain("Check status");
+    const result = buildResumePrompt(context) as any[];
+    expect(result).toEqual([
+      {
+        type: "tool_result",
+        tool_use_id: undefined,
+        content: "Deployed successfully",
+        is_error: undefined,
+      },
+      { type: "text", text: "Check status" },
+    ]);
   });
 
-  it("returns empty string when no user message found", () => {
+  it("resumes from trailing tool results with no final user message", () => {
+    const context = {
+      messages: [
+        { role: "user", content: "Read a file" },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "tool_1",
+              name: "read",
+              arguments: { path: "/foo.ts" },
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "tool_1",
+          toolName: "read",
+          content: "file contents here",
+        },
+      ],
+    };
+
+    expect(buildResumePrompt(context)).toEqual([
+      {
+        type: "tool_result",
+        tool_use_id: "tool_1",
+        content: "file contents here",
+        is_error: undefined,
+      },
+    ]);
+  });
+
+  it("resumes from complete parallel tool results before final user message", () => {
+    const context = {
+      messages: [
+        { role: "user", content: "Read two files" },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "tool_a",
+              name: "read",
+              arguments: { path: "/a.ts" },
+            },
+            {
+              type: "toolCall",
+              id: "tool_b",
+              name: "read",
+              arguments: { path: "/b.ts" },
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "tool_a",
+          toolName: "read",
+          content: "contents of a",
+        },
+        {
+          role: "toolResult",
+          toolCallId: "tool_b",
+          toolName: "read",
+          content: "contents of b",
+        },
+        { role: "user", content: "Compare them" },
+      ],
+    };
+
+    const result = buildResumePrompt(context) as any[];
+    expect(result).toEqual([
+      {
+        type: "tool_result",
+        tool_use_id: "tool_a",
+        content: "contents of a",
+        is_error: undefined,
+      },
+      {
+        type: "tool_result",
+        tool_use_id: "tool_b",
+        content: "contents of b",
+        is_error: undefined,
+      },
+      { type: "text", text: "Compare them" },
+    ]);
+  });
+
+  it("returns empty string for incomplete parallel tool-result batch", () => {
+    const context = {
+      messages: [
+        { role: "user", content: "Read two files" },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "toolCall",
+              id: "tool_a",
+              name: "read",
+              arguments: { path: "/a.ts" },
+            },
+            {
+              type: "toolCall",
+              id: "tool_b",
+              name: "read",
+              arguments: { path: "/b.ts" },
+            },
+          ],
+        },
+        {
+          role: "toolResult",
+          toolCallId: "tool_a",
+          toolName: "read",
+          content: "contents of a",
+        },
+      ],
+    };
+
+    expect(buildResumePrompt(context)).toBe("");
+  });
+
+  it("returns empty string when no resumable user or tool-result input found", () => {
     const context = {
       messages: [{ role: "assistant", content: "Hello" }],
     };
@@ -1039,7 +1189,9 @@ describe("buildResumePrompt", () => {
         },
       ],
     };
-    expect(buildResumePrompt(context)).toBe("Hello from blocks");
+    expect(buildResumePrompt(context)).toEqual([
+      { type: "text", text: "Hello from blocks" },
+    ]);
   });
 
   it("handles images in the final user message by returning ContentBlock[]", () => {

--- a/tests/provider.test.ts
+++ b/tests/provider.test.ts
@@ -259,6 +259,40 @@ describe("streamViaCli", () => {
     expect(eventTypes).toContain("done");
   });
 
+  it("uses result.text as fallback when Claude emits no streamed content blocks", async () => {
+    const model = mockModels[0] as any;
+    const context = {
+      messages: [{ role: "user", content: "Hello" }],
+    };
+
+    streamViaCli(model, context);
+    await vi.advanceTimersByTimeAsync(0);
+
+    const proc = (spawn as any).mock.results[0].value;
+
+    const lines = [
+      JSON.stringify({ type: "system", subtype: "init", session_id: "test" }),
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        result: "Hello from result fallback",
+      }),
+    ];
+
+    for (const line of lines) {
+      proc.stdout.write(line + "\n");
+    }
+    proc.stdout.end();
+    await vi.advanceTimersByTimeAsync(100);
+
+    const mockStream = MockAssistantMessageEventStream.mock.instances[0];
+    const doneEvent = mockStream._events.find((e: any) => e.type === "done");
+    expect(doneEvent).toBeDefined();
+    expect(doneEvent.message.content).toEqual([
+      { type: "text", text: "Hello from result fallback" },
+    ]);
+  });
+
   it("handles result error by pushing error event", async () => {
     const model = mockModels[0] as any;
     const context = {
@@ -1832,6 +1866,48 @@ describe("streamViaCli", () => {
       await vi.advanceTimersByTimeAsync(100);
     });
 
+    it("does not pass --resume when context includes tool results", async () => {
+      const model = mockModels[0] as any;
+      const context = {
+        messages: [
+          { role: "user", content: "Hello" },
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "toolCall",
+                id: "tool_1",
+                name: "bash",
+                arguments: { command: "pwd" },
+              },
+            ],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "tool_1",
+            toolName: "bash",
+            content: "ok",
+          },
+        ],
+      };
+
+      streamViaCli(model, context, { sessionId: "sess-abc-123" } as any);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const args = (spawn as any).mock.calls[0][1] as string[];
+      expect(args).not.toContain("--resume");
+      expect(args).not.toContain("--session-id");
+
+      const proc = (spawn as any).mock.results[0].value;
+      const written = proc.stdin.write.mock.calls[0][0] as string;
+      const parsed = JSON.parse(written.trim());
+      expect(typeof parsed.message.content).toBe("string");
+      expect(parsed.message.content).toContain("TOOL RESULT (historical Bash):");
+
+      proc.stdout.end();
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
     it("does not pass --resume or --session-id when no sessionId option", async () => {
       const model = mockModels[0] as any;
       const context = {
@@ -1868,7 +1944,9 @@ describe("streamViaCli", () => {
       const written = proc.stdin.write.mock.calls[0][0] as string;
       const parsed = JSON.parse(written.trim());
       // Should only contain the latest user message, not full history
-      expect(parsed.message.content).toBe("follow-up");
+      expect(parsed.message.content).toEqual([
+        { type: "text", text: "follow-up" },
+      ]);
 
       // Clean up
       proc.stdout.end();


### PR DESCRIPTION
This extension was sending a `SIGKILL` to the `claude -p` session immediately upon seeing tool call blocks, but that was breaking other assumptions, and resuming such sessions with `--resume` was broken.

This change does away with the kill approach, instead beginning a fresh claude session each time and rebuilding the session history on the pi side.

I've been successfully running multi-turn sessions through pi -> claude code with this fix in place.