### PR TITLE
Replace entire claude code system prompt, rather than appending

### DIFF
--- a/src/process-manager.ts
+++ b/src/process-manager.ts
@@ -17,7 +17,7 @@ import type { ChildProcess } from "node:child_process";
  * Spawn a Claude CLI subprocess with all required flags for stream-json communication.
  *
  * @param modelId - The model ID to pass via --model flag
- * @param systemPrompt - Optional system prompt appended via --append-system-prompt
+ * @param systemPrompt - Optional system prompt passed via --system-prompt (replaces CLI default)
  * @param options - Optional cwd, AbortSignal, and effort level
  * @returns The spawned ChildProcess with piped stdin/stdout/stderr
  */
@@ -57,13 +57,15 @@ export function spawnClaude(
 
   if (systemPrompt) {
     // Write system prompt to a temp file to avoid ENAMETOOLONG on Windows.
-    // Claude CLI's --append-system-prompt accepts a file path or literal text.
+    // Use --system-prompt (not --append-system-prompt) so the CLI's default
+    // system prompt is fully replaced — giving pi users the benefit of minimal
+    // pre-prompting rather than layering on top of Claude Code's verbose defaults.
     const tmpFile = join(
       tmpdir(),
       `pi-claude-cli-sysprompt-${process.pid}.txt`,
     );
     writeFileSync(tmpFile, systemPrompt, "utf-8");
-    args.push("--append-system-prompt", tmpFile);
+    args.push("--system-prompt", tmpFile);
   }
 
   if (options?.effort) {

--- a/src/prompt-builder.ts
+++ b/src/prompt-builder.ts
@@ -349,8 +349,89 @@ function findFinalUserMessageIndex(messages: any[]): number {
 }
 
 /**
+ * Claude Code tool names and key parameters, replacing pi's tool-specific sections.
+ *
+ * When using --system-prompt to replace Claude Code's default prompt, the LLM
+ * sees tool definitions from the API (Read, Write, Edit, Bash, Grep, Glob)
+ * but NOT behavioral guidance about when/how to use them. This replacement
+ * section provides that guidance using correct Claude Code tool names and
+ * parameter names, so the LLM gets proper usage instructions that match
+ * the actual tool schemas.
+ */
+const CLAUDE_CODE_TOOLS_SECTION = `
+Available tools:
+- Read: Read file contents (key param: file_path)
+- Write: Create or overwrite files (key params: file_path, content)
+- Edit: Make precise edits with exact text replacement (key params: file_path, old_string, new_string)
+- Bash: Execute bash commands (key param: command)
+- Grep: Search file contents for patterns (key params: pattern, path)
+- Glob: Find files by glob pattern (key params: pattern, path)
+
+You also have access to custom project tools registered via MCP.
+
+Guidelines:
+- Prefer Grep and Glob over Bash for file exploration (faster, respects .gitignore)
+- Use Read to examine files before editing
+- Use Edit for precise changes (old_string must match exactly)
+- Use Write only for new files or complete rewrites
+- When summarizing your actions, output plain text directly - do NOT use Bash to display what you did
+- Be concise in your responses
+- Show file paths clearly when working with files`.trim();
+
+/**
+ * Replace pi's tool-specific sections ("Available tools:" through "Guidelines:")
+ * in the system prompt with Claude Code–correct equivalents.
+ *
+ * Pi's system prompt includes tool descriptions and guidelines that use pi's
+ * lowercase tool names (read, edit, grep, find, ls) and parameter names
+ * (path, oldText, newText). When routed through Claude Code, the LLM sees
+ * different tool schemas: PascalCase names (Read, Edit, Grep, Glob) and
+ * different parameter names (file_path, old_string, new_string). The pi
+ * sections are actively misleading in that context. This function strips them
+ * and replaces them with a section that matches Claude Code's actual tools.
+ *
+ * If the expected sections are not found (e.g., pi changes its format),
+ * the original prompt is returned unchanged — worst case is a slightly
+ * misleading prompt, not a crash.
+ */
+function replacePiToolSections(systemPrompt: string): string {
+  // Split into double-newline-separated blocks
+  const blocks = systemPrompt.split("\n\n");
+
+  // Find the indices of the tool-specific sections
+  const availableToolsIdx = blocks.findIndex((block) =>
+    block.startsWith("Available tools:\n"),
+  );
+  const guidelinesIdx = blocks.findIndex((block) =>
+    block.startsWith("Guidelines:\n"),
+  );
+
+  // If we can't find both sections, return the prompt unchanged
+  if (availableToolsIdx === -1 || guidelinesIdx === -1) {
+    return systemPrompt;
+  }
+
+  // Remove blocks from "Available tools:" through "Guidelines:" (inclusive)
+  // This also removes the "In addition to the tools above" line between them
+  const filtered = blocks.filter(
+    (_, idx) => idx < availableToolsIdx || idx > guidelinesIdx,
+  );
+
+  // Insert the Claude Code replacement after the intro paragraph
+  // (which is the first block)
+  if (filtered.length > 0) {
+    filtered.splice(1, 0, CLAUDE_CODE_TOOLS_SECTION);
+  } else {
+    filtered.push(CLAUDE_CODE_TOOLS_SECTION);
+  }
+
+  return filtered.join("\n\n");
+}
+
+/**
  * Builds the system prompt from the context's systemPrompt field,
- * appending AGENTS.md content if found (walking up from cwd, then global fallback).
+ * replacing pi's tool sections with Claude Code equivalents,
+ * then appending AGENTS.md content if found.
  * Sanitizes .pi references to .claude for Claude Code compatibility.
  */
 export function buildSystemPrompt(
@@ -360,7 +441,12 @@ export function buildSystemPrompt(
   const parts: string[] = [];
 
   if (context.systemPrompt) {
-    parts.push(context.systemPrompt);
+    // Replace pi's tool-specific sections with Claude Code equivalents
+    // before passing the system prompt through to the subprocess.
+    // Pi uses lowercase names (read, grep, find, ls) and different parameter
+    // names (path, oldText, newText) that don't match Claude Code's tools
+    // (Read, Edit, Grep, Glob with file_path, old_string, new_string).
+    parts.push(replacePiToolSections(context.systemPrompt));
   }
 
   // Look for AGENTS.md

--- a/tests/process-manager.test.ts
+++ b/tests/process-manager.test.ts
@@ -91,12 +91,12 @@ describe("spawnClaude", () => {
     expect(options.cwd).toBe("/custom/path");
   });
 
-  it("writes system prompt to temp file and passes path via --append-system-prompt", () => {
+  it("writes system prompt to temp file and passes path via --system-prompt", () => {
     spawnClaude("claude-sonnet-4-5-20250929", "You are a helpful assistant.");
     const args = (spawn as any).mock.calls[0][1] as string[];
 
-    expect(args).toContain("--append-system-prompt");
-    const idx = args.indexOf("--append-system-prompt");
+    expect(args).toContain("--system-prompt");
+    const idx = args.indexOf("--system-prompt");
     expect(args[idx + 1]).toContain("pi-claude-cli-sysprompt-");
   });
 
@@ -110,10 +110,10 @@ describe("spawnClaude", () => {
     expect(readFileSync(tmpFile, "utf-8")).toBe("You are a helpful assistant.");
   });
 
-  it("does not include --append-system-prompt when no system prompt", () => {
+  it("does not include --system-prompt when no system prompt", () => {
     spawnClaude("claude-sonnet-4-5-20250929");
     const args = (spawn as any).mock.calls[0][1] as string[];
-    expect(args).not.toContain("--append-system-prompt");
+    expect(args).not.toContain("--system-prompt");
   });
 
   it("returns the spawned ChildProcess", () => {
@@ -175,7 +175,7 @@ describe("effort flag", () => {
     });
     const args = (spawn as any).mock.calls[0][1] as string[];
 
-    expect(args).toContain("--append-system-prompt");
+    expect(args).toContain("--system-prompt");
     expect(args).not.toContain("--effort");
   });
 });
@@ -419,7 +419,7 @@ describe("mcp-config flag", () => {
     });
     const args = (spawn as any).mock.calls[0][1] as string[];
 
-    expect(args).toContain("--append-system-prompt");
+    expect(args).toContain("--system-prompt");
     expect(args).toContain("--effort");
     expect(args).not.toContain("--mcp-config");
     expect(args).toContain("--permission-prompt-tool");

--- a/tests/prompt-builder.test.ts
+++ b/tests/prompt-builder.test.ts
@@ -1065,3 +1065,259 @@ describe("buildResumePrompt", () => {
     expect((result as any[])[1].type).toBe("image");
   });
 });
+
+describe("replacePiToolSections", () => {
+  // Import the function we need to test. It's not exported, so we test it
+  // indirectly through buildSystemPrompt, but we can also test the logic
+  // by constructing a pi-style system prompt and verifying transformation.
+
+  /**
+   * Build a realistic pi system prompt for testing.
+   * Mirrors the structure from pi-coding-agent's buildSystemPrompt().
+   */
+  function buildPiSystemPrompt(tools: string[] = ["read", "bash", "edit", "write", "grep", "find", "ls"]): string {
+    const toolDescriptions: Record<string, string> = {
+      read: "Read file contents",
+      bash: "Execute bash commands (ls, grep, find, etc.)",
+      edit: "Make surgical edits to files (find exact text and replace)",
+      write: "Create or overwrite files",
+      grep: "Search file contents for patterns (respects .gitignore)",
+      find: "Find files by glob pattern (respects .gitignore)",
+      ls: "List directory contents",
+    };
+    const toolsList = tools.map((t) => `- ${t}: ${toolDescriptions[t]}`).join("\n");
+    const guidelinesList: string[] = [];
+    if (tools.includes("bash") && (tools.includes("grep") || tools.includes("find") || tools.includes("ls"))) {
+      guidelinesList.push("Prefer grep/find/ls tools over bash for file exploration (faster, respects .gitignore)");
+    }
+    if (tools.includes("read") && tools.includes("edit")) {
+      guidelinesList.push("Use read to examine files before editing. You must use this tool instead of cat or sed.");
+    }
+    if (tools.includes("edit")) {
+      guidelinesList.push("Use edit for precise changes (old text must match exactly)");
+    }
+    if (tools.includes("write")) {
+      guidelinesList.push("Use write only for new files or complete rewrites");
+    }
+    guidelinesList.push("Be concise in your responses");
+    guidelinesList.push("Show file paths clearly when working with files");
+    const guidelines = guidelinesList.map((g) => `- ${g}`).join("\n");
+
+    return `You are an expert coding assistant operating inside pi, a coding agent harness. You help users by reading files, executing commands, editing code, and writing new files.
+
+Available tools:
+${toolsList}
+
+In addition to the tools above, you may have access to other custom tools depending on the project.
+
+Guidelines:
+${guidelines}
+
+Pi documentation (read only when the user asks about pi itself, its SDK, extensions, themes, skills, or TUI):
+- Main documentation: /path/to/readme
+- Additional docs: /path/to/docs
+- When working on pi topics, read the docs and examples
+
+Current date and time: Friday, April 17, 2026 at 12:00:00 PM EDT
+Current working directory: /some/project`;
+  }
+
+  it("replaces Available tools through Guidelines sections with Claude Code equivalents", async () => {
+    vi.doMock("node:fs", () => ({
+      existsSync: () => false,
+      readFileSync: () => "",
+    }));
+
+    const { buildSystemPrompt: bsp } = await import("../src/prompt-builder");
+    const context = {
+      systemPrompt: buildPiSystemPrompt(),
+      messages: [],
+    } as unknown as any;
+    const result = bsp(context, "/some/project");
+
+    // Should contain Claude Code tool names
+    expect(result).toContain("Read");
+    expect(result).toContain("Write");
+    expect(result).toContain("Edit");
+    expect(result).toContain("Bash");
+    expect(result).toContain("Grep");
+    expect(result).toContain("Glob");
+
+    // Should contain Claude Code parameter names
+    expect(result).toContain("file_path");
+    expect(result).toContain("old_string");
+    expect(result).toContain("new_string");
+
+    // Should NOT contain pi's tool names in tool-reference context
+    // (they may still appear in other contexts like "writing files")
+    expect(result).not.toMatch(/Available tools:\n- read:/);
+    expect(result).not.toMatch(/Available tools:\n- grep:/);
+    expect(result).not.toMatch(/Available tools:\n- find:/);
+
+    // Should NOT contain pi-specific guidelines
+    expect(result).not.toContain("Use read to examine files");
+    expect(result).not.toContain("Use edit for precise changes (old text must match exactly)");
+    expect(result).not.toContain("Use write only for new files or complete rewrites");
+    expect(result).not.toContain("Prefer grep/find/ls tools over bash");
+
+    // Should contain Claude Code-appropriate guidelines
+    expect(result).toContain("Use Read to examine files before editing");
+    expect(result).toContain("Use Edit for precise changes (old_string must match exactly)");
+    expect(result).toContain("Use Write only for new files or complete rewrites");
+    expect(result).toContain("Prefer Grep and Glob over Bash for file exploration");
+
+    // Should NOT contain "In addition to the tools above" (references removed section)
+    expect(result).not.toContain("In addition to the tools above");
+  });
+
+  it("preserves sections before Available tools and after Guidelines", async () => {
+    vi.doMock("node:fs", () => ({
+      existsSync: () => false,
+      readFileSync: () => "",
+    }));
+
+    const { buildSystemPrompt: bsp } = await import("../src/prompt-builder");
+    const context = {
+      systemPrompt: buildPiSystemPrompt(),
+      messages: [],
+    } as unknown as any;
+    const result = bsp(context, "/some/project");
+
+    // Intro paragraph should be preserved
+    expect(result).toContain("You are an expert coding assistant operating inside pi");
+
+    // Pi documentation section should be preserved
+    expect(result).toContain("Pi documentation");
+    expect(result).toContain("Main documentation");
+
+    // Date/time and working directory should be preserved
+    expect(result).toContain("Current date and time:");
+    expect(result).toContain("Current working directory:");
+  });
+
+  it("passes through system prompt unchanged when Available tools section is missing", async () => {
+    vi.doMock("node:fs", () => ({
+      existsSync: () => false,
+      readFileSync: () => "",
+    }));
+
+    const { buildSystemPrompt: bsp } = await import("../src/prompt-builder");
+    const context = {
+      systemPrompt: "You are a helpful assistant.\n\nGuidelines:\n- Be concise",
+      messages: [],
+    } as unknown as any;
+    const result = bsp(context, "/some/project");
+
+    // Should be unchanged (no "Available tools:" section found)
+    expect(result).toBe("You are a helpful assistant.\n\nGuidelines:\n- Be concise");
+  });
+
+  it("passes through system prompt unchanged when Guidelines section is missing", async () => {
+    vi.doMock("node:fs", () => () => ({
+      existsSync: () => false,
+      readFileSync: () => "",
+    }));
+
+    const { buildSystemPrompt: bsp } = await import("../src/prompt-builder");
+    const context = {
+      systemPrompt: "You are a helpful assistant.\n\nAvailable tools:\n- read: Read files",
+      messages: [],
+    } as unknown as any;
+    const result = bsp(context, "/some/project");
+
+    // Should be unchanged (no "Guidelines:" section found)
+    expect(result).toBe("You are a helpful assistant.\n\nAvailable tools:\n- read: Read files");
+  });
+
+  it("handles minimal system prompt with just intro and tools", async () => {
+    vi.doMock("node:fs", () => ({
+      existsSync: () => false,
+      readFileSync: () => "",
+    }));
+
+    const { buildSystemPrompt: bsp } = await import("../src/prompt-builder");
+    const context = {
+      systemPrompt: "Intro text\n\nAvailable tools:\n- read: Read\n- write: Write\n\nGuidelines:\n- Be good\n- Be fast",
+      messages: [],
+    } as unknown as any;
+    const result = bsp(context, "/some/project");
+
+    expect(result).toContain("Intro text");
+    expect(result).toContain("Read");
+    expect(result).toContain("Glob");
+    expect(result).not.toContain("- read: Read");
+    expect(result).not.toContain("- Be good"); // Old guidelines removed
+  });
+
+  it("works with custom system prompt (no tool sections at all)", async () => {
+    vi.doMock("node:fs", () => ({
+      existsSync: () => false,
+      readFileSync: () => "",
+    }));
+
+    const { buildSystemPrompt: bsp } = await import("../src/prompt-builder");
+    const context = {
+      systemPrompt: "You are a specialized assistant for React development.",
+      messages: [],
+    } as unknown as any;
+    const result = bsp(context, "/some/project");
+
+    // Custom prompt without tool sections should pass through unchanged
+    expect(result).toBe("You are a specialized assistant for React development.");
+  });
+
+  it("places Claude Code tools section between intro and remaining sections", async () => {
+    vi.doMock("node:fs", () => ({
+      existsSync: () => false,
+      readFileSync: () => "",
+    }));
+
+    const { buildSystemPrompt: bsp } = await import("../src/prompt-builder");
+    const context = {
+      systemPrompt: buildPiSystemPrompt(),
+      messages: [],
+    } as unknown as any;
+    const result = bsp(context, "/some/project");
+
+    // The Claude Code tools section should come after the intro
+    const introIdx = result.indexOf("You are an expert coding assistant");
+    const toolsIdx = result.indexOf("Available tools:");
+    const piDocsIdx = result.indexOf("Pi documentation");
+
+    expect(introIdx).toBeLessThan(toolsIdx);
+    expect(toolsIdx).toBeLessThan(piDocsIdx);
+  });
+
+  it("removes the 'In addition to the tools above' line", async () => {
+    vi.doMock("node:fs", () => ({
+      existsSync: () => false,
+      readFileSync: () => "",
+    }));
+
+    const { buildSystemPrompt: bsp } = await import("../src/prompt-builder");
+    const prompt = buildPiSystemPrompt();
+    expect(prompt).toContain("In addition to the tools above"); // Verify it's there initially
+
+    const context = {
+      systemPrompt: prompt,
+      messages: [],
+    } as unknown as any;
+    const result = bsp(context, "/some/project");
+    expect(result).not.toContain("In addition to the tools above");
+  });
+
+  it("handles empty system prompt", async () => {
+    vi.doMock("node:fs", () => ({
+      existsSync: () => false,
+      readFileSync: () => "",
+    }));
+
+    const { buildSystemPrompt: bsp } = await import("../src/prompt-builder");
+    const context = {
+      systemPrompt: "",
+      messages: [],
+    } as unknown as any;
+    const result = bsp(context, "/some/project");
+    expect(result).toBe("");
+  });
+});

--- a/tests/provider.test.ts
+++ b/tests/provider.test.ts
@@ -1891,7 +1891,7 @@ describe("streamViaCli", () => {
 
       const args = (spawn as any).mock.calls[0][1] as string[];
       expect(args).toContain("--resume");
-      expect(args).not.toContain("--append-system-prompt");
+      expect(args).not.toContain("--system-prompt");
 
       // Clean up
       const proc = (spawn as any).mock.results[0].value;


### PR DESCRIPTION
Part of the major benefit of a minimal agent like pi is the reduced context/instruction use. But by starting claude code with --append-system-prompt, it only makes cc's own system prompt _even longer_.

This change swaps --append-system-prompt with --system-prompt so that pi's system prompt is dropped into the claude code delegate.

Pi's system prompt contains sections which document pi's own tools, however. So this change also identifies those sections in the system prompt and replaces them with a version of the same which instead references the tool and parameter names of claude code's own tools.