### PR TITLE
Only activate grep and find as extra pi tools for Claude Code sessions

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -81,14 +81,7 @@ export default function (pi: ExtensionAPI) {
       maxTokens: model.maxTokens,
     }));
 
-    // Ensure all registered tools are active so pi can execute them.
-    // Some tools (find, grep, ls) are registered but not activated by default.
-    pi.on("session_start", async () => {
-      const allTools = pi.getAllTools();
-      if (Array.isArray(allTools)) {
-        pi.setActiveTools(allTools.map((t: any) => t.name));
-      }
-    });
+
 
     pi.registerProvider(PROVIDER_ID, {
       baseUrl: "pi-claude-cli",
@@ -96,6 +89,16 @@ export default function (pi: ExtensionAPI) {
       api: "pi-claude-cli",
       models,
       streamSimple: (model, context, options) => {
+        // Activate grep and find on every call. These are off-by-default in pi
+        // but Claude Code expects them (via Bash fallbacks). Explicitly naming
+        // the tools we need is more future-proof than "all except ls" — if pi
+        // adds more off-by-default tools, they won't be silently activated.
+        const active = new Set(pi.getActiveTools());
+        active.add("grep");
+        active.add("find");
+        active.delete("ls");
+        pi.setActiveTools([...active]);
+
         const configPath = ensureMcpConfig(pi);
         return streamViaCli(model, context, {
           ...options,

--- a/src/mcp-config.ts
+++ b/src/mcp-config.ts
@@ -10,7 +10,16 @@ import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 
-/** The 6 built-in tools that pi handles natively (match pi tool names). */
+/** The 6 built-in pi tools that have Claude Code equivalents.
+ *
+ * These are handled natively by the extension's event bridge (mapped to Read,
+ * Write, Edit, Bash, Grep, Glob). They must NOT be registered as custom MCP
+ * tools because Claude Code provides its own definitions for them.
+ *
+ * Other pi built-in tools (like ls) that lack Claude Code equivalents should
+ * be treated as custom tools when activated — they get registered via MCP
+ * so Claude Code can call them through the custom-tools bridge. If not
+ * activated, getActiveTools() filtering ensures they're excluded. */
 const BUILT_IN_TOOL_NAMES = new Set([
   "read",
   "write",
@@ -28,7 +37,14 @@ export interface McpToolDef {
 }
 
 /**
- * Get custom tool definitions from pi, filtering out built-in tools.
+ * Get custom tool definitions from pi, filtering out built-in tools and
+ * any tools that are not currently active.
+ *
+ * getAllTools() returns all registered tools regardless of activation status.
+ * getActiveTools() returns only the names of currently active tools.
+ * We filter by both: built-in tools are excluded (they have Claude Code
+ * equivalents), and inactive tools are excluded (they shouldn't be exposed
+ * to Claude Code if no extension has activated them).
  *
  * @param pi - The pi ExtensionAPI instance
  * @returns Array of custom tool definitions (empty if all tools are built-in)
@@ -40,8 +56,18 @@ export function getCustomToolDefs(pi: any): McpToolDef[] {
     return [];
   }
 
+  // Get active tool names to filter out deactivated tools.
+  // getActiveTools() returns string[] of currently active tool names.
+  // Only active tools should be exposed to Claude Code via MCP.
+  const activeToolNames = new Set(
+    typeof pi.getActiveTools === "function"
+      ? pi.getActiveTools()
+      : allTools.map((t: any) => t.name),
+  );
+
   return allTools
     .filter((tool: any) => !BUILT_IN_TOOL_NAMES.has(tool.name))
+    .filter((tool: any) => activeToolNames.has(tool.name))
     .map((tool: any) => ({
       name: tool.name,
       description: tool.description,

--- a/tests/mcp-config.test.ts
+++ b/tests/mcp-config.test.ts
@@ -24,7 +24,7 @@ describe("getCustomToolDefs", () => {
     vi.clearAllMocks();
   });
 
-  it("filters out all 6 built-in tools and returns only custom tools", () => {
+  it("filters out built-in tools and inactive tools, returning only active custom tools", () => {
     const mockPi = {
       getAllTools: vi.fn(() => [
         {
@@ -51,6 +51,11 @@ describe("getCustomToolDefs", () => {
         {
           name: "find",
           description: "Find files",
+          parameters: { type: "object" },
+        },
+        {
+          name: "ls",
+          description: "List directory",
           parameters: { type: "object" },
         },
         {
@@ -70,16 +75,22 @@ describe("getCustomToolDefs", () => {
           },
         },
       ]),
+      // ls is registered but not activated — should be excluded
+      getActiveTools: vi.fn(() => [
+        "read", "write", "edit", "bash", "grep", "find", "search", "deploy",
+      ]),
     };
 
     const result = getCustomToolDefs(mockPi);
 
+    // ls is filtered out because it's not active
+    // read/write/edit/bash/grep/find are filtered out because they're built-in
     expect(result).toHaveLength(2);
     expect(result[0].name).toBe("search");
     expect(result[1].name).toBe("deploy");
   });
 
-  it("returns empty array when all tools are built-in", () => {
+  it("returns empty array when all active tools are built-in", () => {
     const mockPi = {
       getAllTools: vi.fn(() => [
         {
@@ -108,11 +119,48 @@ describe("getCustomToolDefs", () => {
           description: "Find files",
           parameters: { type: "object" },
         },
+        {
+          name: "ls",
+          description: "List directory",
+          parameters: { type: "object" },
+        },
+      ]),
+      // Only built-in tools are active; ls is inactive
+      getActiveTools: vi.fn(() => [
+        "read", "write", "edit", "bash", "grep", "find",
       ]),
     };
 
     const result = getCustomToolDefs(mockPi);
     expect(result).toEqual([]);
+  });
+
+  it("exposes ls as a custom MCP tool when another extension activates it", () => {
+    const mockPi = {
+      getAllTools: vi.fn(() => [
+        { name: "read", description: "Read file", parameters: { type: "object" } },
+        { name: "write", description: "Write file", parameters: { type: "object" } },
+        { name: "edit", description: "Edit file", parameters: { type: "object" } },
+        { name: "bash", description: "Run bash", parameters: { type: "object" } },
+        { name: "grep", description: "Search", parameters: { type: "object" } },
+        { name: "find", description: "Find files", parameters: { type: "object" } },
+        { name: "ls", description: "List directory", parameters: { type: "object" } },
+        { name: "deploy", description: "Deploy app", parameters: { type: "object", properties: { target: { type: "string" } } } },
+      ]),
+      // Another extension activated ls, so it's in the active set
+      getActiveTools: vi.fn(() => [
+        "read", "write", "edit", "bash", "grep", "find", "ls", "deploy",
+      ]),
+    };
+
+    const result = getCustomToolDefs(mockPi);
+
+    // ls is not built-in but IS active → exposed as custom MCP tool
+    // deploy is also custom and active
+    // read/write/edit/bash/grep/find are built-in → excluded
+    expect(result).toHaveLength(2);
+    expect(result.map((t: any) => t.name)).toContain("ls");
+    expect(result.map((t: any) => t.name)).toContain("deploy");
   });
 
   it("includes custom tool with correct name, description, inputSchema from parameters", () => {
@@ -133,6 +181,7 @@ describe("getCustomToolDefs", () => {
           parameters: customParams,
         },
       ]),
+      getActiveTools: vi.fn(() => ["custom_search"]),
     };
 
     const result = getCustomToolDefs(mockPi);


### PR DESCRIPTION
pi-claude-cli was previously using the session_start event to activate all of pi's internal tools, adding grep, find, and ls to the 4 tools that are activated by default. Ostensibly this is to bring pi's tool capabilities up to par with claude code's so that all claude code tool calls can be straightforwardly mapped.

But for that it:
- doesn't need to include the ls tool
- only necessarily needs to add tool activations on pi-claude-cli sessions

So, this change updates the approach used to:
- only activate grep and find (for claude code's Grep and Glob tools)
- does so as part of the registerProvider() call to only affect sessions being routed through pi-claude-cli.

If the ls tool is activated anyway (by some other extension), this extension now treats it the same way as MCP tools which are in the same boat: surfacing extended pi capabilities to the managed claude code.