### PR TITLE
fix: don't --resume a CLI session that doesn't exist (cross-provider /model switch)

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -81,13 +81,21 @@ export function streamViaCli(
     try {
       const cwd = options?.cwd ?? process.cwd();
 
-      // Resume if pi provides a session ID AND this isn't the first turn.
-      // Pi passes sessionId on every call (including first), but we can only
-      // --resume a CLI session that already exists on disk from a prior turn.
+      // Resume only when this conversation already contains a prior assistant
+      // turn produced by pi-claude-cli (which means a CLI session has been
+      // established under this session id). Otherwise — e.g. when the user
+      // just switched to pi-claude-cli from another provider mid session, or
+      // when this is the first turn — start a fresh CLI session via
+      // --session-id. Using --resume against an unknown id fails silently
+      // with "No conversation found with session ID" and produces an empty
+      // assistant message.
+      const hasPriorCliTurn = (context.messages as any[]).some(
+        (m) =>
+          m?.role === "assistant" &&
+          (m?.provider === "pi-claude-cli" || m?.api === "pi-claude-cli"),
+      );
       const resumeSessionId =
-        options?.sessionId && context.messages.length > 1
-          ? options.sessionId
-          : undefined;
+        options?.sessionId && hasPriorCliTurn ? options.sessionId : undefined;
 
       // Build prompt: if resuming, only send the latest user turn;
       // otherwise build the full flattened conversation history
@@ -271,8 +279,23 @@ export function streamViaCli(
         } else if (msg.type === "control_request") {
           handleControlRequest(msg, proc!.stdin!);
         } else if (msg.type === "result") {
-          if (msg.subtype === "error") {
-            endStreamWithError(msg.error ?? "Unknown error from Claude CLI");
+          // Surface every non-success result as an error so silent failures
+          // (e.g. subtype "error_during_execution" from --resume against an
+          // unknown session id, or any future error variant) don't get
+          // swallowed into an empty assistant message.
+          const r: any = msg as any;
+          const isError =
+            r.subtype !== "success" ||
+            r.is_error === true ||
+            typeof r.error === "string" ||
+            (Array.isArray(r.errors) && r.errors.length > 0);
+          if (isError) {
+            const errMsg =
+              r.error ??
+              (Array.isArray(r.errors) && r.errors.length > 0
+                ? r.errors.join("; ")
+                : `Claude CLI returned ${r.subtype ?? "non-success result"}`);
+            endStreamWithError(errMsg);
           }
           // For both success and error: clean up the subprocess
           clearTimeout(inactivityTimer);

--- a/tests/provider.test.ts
+++ b/tests/provider.test.ts
@@ -1792,7 +1792,12 @@ describe("streamViaCli", () => {
       const context = {
         messages: [
           { role: "user", content: "Hello" },
-          { role: "assistant", content: "Hi" },
+          {
+            role: "assistant",
+            content: "Hi",
+            provider: "pi-claude-cli",
+            api: "pi-claude-cli",
+          },
           { role: "user", content: "Follow-up" },
         ],
       };
@@ -1856,7 +1861,12 @@ describe("streamViaCli", () => {
       const context = {
         messages: [
           { role: "user", content: "first message" },
-          { role: "assistant", content: "response" },
+          {
+            role: "assistant",
+            content: "response",
+            provider: "pi-claude-cli",
+            api: "pi-claude-cli",
+          },
           { role: "user", content: "follow-up" },
         ],
       };
@@ -1880,7 +1890,12 @@ describe("streamViaCli", () => {
       const context = {
         messages: [
           { role: "user", content: "Hello" },
-          { role: "assistant", content: "Hi" },
+          {
+            role: "assistant",
+            content: "Hi",
+            provider: "pi-claude-cli",
+            api: "pi-claude-cli",
+          },
           { role: "user", content: "follow-up" },
         ],
         systemPrompt: "Be helpful",
@@ -1897,6 +1912,100 @@ describe("streamViaCli", () => {
       const proc = (spawn as any).mock.results[0].value;
       proc.stdout.end();
       await vi.advanceTimersByTimeAsync(100);
+    });
+
+    it("uses --session-id (not --resume) when prior assistant turns are from a different provider", async () => {
+      // Regression test: switching to pi-claude-cli mid-session from another
+      // provider must not --resume a CLI session that was never created,
+      // because `claude --resume <unknown>` fails silently and pi receives
+      // an empty assistant message.
+      const model = mockModels[0] as any;
+      const context = {
+        messages: [
+          { role: "user", content: "earlier prompt" },
+          {
+            role: "assistant",
+            content: "earlier reply",
+            provider: "anthropic",
+            api: "anthropic",
+          },
+          { role: "user", content: "first pi-claude-cli prompt" },
+        ],
+        systemPrompt: "Be helpful",
+      };
+
+      streamViaCli(model, context, { sessionId: "sess-cross" } as any);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const args = (spawn as any).mock.calls[0][1] as string[];
+      expect(args).not.toContain("--resume");
+      expect(args).toContain("--session-id");
+      const idx = args.indexOf("--session-id");
+      expect(args[idx + 1]).toBe("sess-cross");
+      // Fresh session must send the system prompt and full history.
+      expect(args).toContain("--append-system-prompt");
+
+      // Clean up
+      const proc = (spawn as any).mock.results[0].value;
+      proc.stdout.end();
+      await vi.advanceTimersByTimeAsync(100);
+    });
+  });
+
+  describe("non-success result surfacing", () => {
+    function findErrorText(): string {
+      const mockStream = MockAssistantMessageEventStream.mock.instances[0];
+      const doneEvent = mockStream._events.find(
+        (e: any) => e.type === "done" && e.message,
+      );
+      expect(doneEvent).toBeDefined();
+      return (doneEvent.message.content ?? [])
+        .filter((c: any) => c.type === "text")
+        .map((c: any) => c.text)
+        .join("");
+    }
+
+    it("surfaces result.subtype = 'error_during_execution' as an error", async () => {
+      const model = mockModels[0] as any;
+      const context = { messages: [{ role: "user", content: "hi" }] };
+
+      streamViaCli(model, context);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const proc = (spawn as any).mock.results[0].value;
+      proc.stdout.write(
+        JSON.stringify({
+          type: "result",
+          subtype: "error_during_execution",
+          errors: ["No conversation found with session ID: sess-xyz"],
+        }) + "\n",
+      );
+      proc.stdout.end();
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(findErrorText()).toMatch(/No conversation found/);
+    });
+
+    it("surfaces result with is_error: true as an error", async () => {
+      const model = mockModels[0] as any;
+      const context = { messages: [{ role: "user", content: "hi" }] };
+
+      streamViaCli(model, context);
+      await vi.advanceTimersByTimeAsync(0);
+
+      const proc = (spawn as any).mock.results[0].value;
+      proc.stdout.write(
+        JSON.stringify({
+          type: "result",
+          subtype: "success",
+          is_error: true,
+          error: "boom",
+        }) + "\n",
+      );
+      proc.stdout.end();
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(findErrorText()).toMatch(/boom/);
     });
   });
 });


### PR DESCRIPTION
## Symptom

After selecting a `pi-claude-cli` model via `/model` mid-session (i.e. when the active conversation already has prior assistant turns from another provider like `anthropic`), the next prompt produces an empty assistant message — `content: []`, `stopReason: "stop"`, zero usage. From the user's perspective, "nothing happens".

## Root cause

`streamViaCli` decides whether to use `claude --resume <sessionId>` based purely on `context.messages.length > 1`:

```ts
const resumeSessionId =
  options?.sessionId && context.messages.length > 1
    ? options.sessionId
    : undefined;
```

That session id is pi's session id, not a Claude CLI session id. When the user switches *to* pi-claude-cli from another provider mid-session, prior messages exist but **no CLI session was ever created** under that id. So `claude --resume <pi-session-id>` runs against an unknown id:

```
$ echo '{"type":"user",...}' | claude -p --input-format stream-json --output-format stream-json \
    --resume 019e21dd-1c4e-7186-a853-4a93f3de03df
No conversation found with session ID: 019e21dd-1c4e-7186-a853-4a93f3de03df
{"type":"result","subtype":"error_during_execution",...,"errors":["No conversation found..."]}
```

The CLI exits 0 with a `result` whose `subtype` is `"error_during_execution"`. The provider's result handler only treats `subtype === "error"` as an error, so the failure is swallowed and an empty `done` event is pushed.

Reproduced this from a real pi session and confirmed via the saved jsonl: the offending assistant entry has `"content":[]`, `"usage":{...zeros...}`, `"stopReason":"stop"`, and `"provider":"pi-claude-cli"`.

## Fix

Two small changes in `src/provider.ts`:

1. **Resume only when there's a prior `pi-claude-cli` assistant turn** in `context.messages`. Otherwise start a fresh CLI session via `--session-id`. This covers both the first-turn case (already handled before) and the new cross-provider-switch case.

2. **Surface every non-success result** as an error — `subtype !== "success"`, `is_error: true`, or non-empty `errors[]`. This is defense-in-depth so future silent failure modes don't get swallowed into empty assistant messages.

## Tests

- Updated existing resume tests so the prior assistant message declares `provider: "pi-claude-cli"` (matches the real shape pi persists in `.jsonl` sessions).
- New regression test: cross-provider switch must use `--session-id` (not `--resume`) and include the system prompt.
- New tests for the result surfacing path: `subtype: "error_during_execution"` with `errors: [...]`, and `is_error: true` with `error: "..."`.

`npm test` → 299/299 pass. `npm run typecheck`, `npm run lint`, and `npm run format:check` all clean.

## Manual verification

1. Open a pi session, send a couple of prompts on `anthropic/claude-opus-4-7`.
2. `/model` → `pi-claude-cli/claude-opus-4-7`.
3. Send a prompt.

Before the patch: empty assistant message, zero tokens.

After the patch: normal streamed reply, tools work, and any future failure produces a visible `Error: …` message instead of silent emptiness.
