### PR TITLE
fix: pass the system prompt with --append-system-prompt-file

### DIFF
--- a/src/process-manager.ts
+++ b/src/process-manager.ts
@@ -17,7 +17,7 @@ import type { ChildProcess } from "node:child_process";
  * Spawn a Claude CLI subprocess with all required flags for stream-json communication.
  *
  * @param modelId - The model ID to pass via --model flag
- * @param systemPrompt - Optional system prompt appended via --append-system-prompt
+ * @param systemPrompt - Optional system prompt appended via --append-system-prompt-file
  * @param options - Optional cwd, AbortSignal, and effort level
  * @returns The spawned ChildProcess with piped stdin/stdout/stderr
  */
@@ -56,14 +56,19 @@ export function spawnClaude(
   }
 
   if (systemPrompt) {
-    // Write system prompt to a temp file to avoid ENAMETOOLONG on Windows.
-    // Claude CLI's --append-system-prompt accepts a file path or literal text.
+    // Write the system prompt to a temp file rather than passing it inline: a pi system
+    // prompt carrying context files and skill descriptions runs to tens of kilobytes, and
+    // Windows caps an entire command line at 32,767 characters.
+    //
+    // The flag has to be --append-system-prompt-file. --append-system-prompt takes literal
+    // text, so handing it a path appends the path itself, and the prompt never reaches the
+    // model — silently, because a path is valid text.
     const tmpFile = join(
       tmpdir(),
       `pi-claude-cli-sysprompt-${process.pid}.txt`,
     );
     writeFileSync(tmpFile, systemPrompt, "utf-8");
-    args.push("--append-system-prompt", tmpFile);
+    args.push("--append-system-prompt-file", tmpFile);
   }
 
   if (options?.effort) {

--- a/tests/cli-contract.test.ts
+++ b/tests/cli-contract.test.ts
@@ -13,30 +13,30 @@
  * They skip when `claude` is not on PATH, so they are inert in an environment without the CLI.
  */
 
-import { execFileSync } from "node:child_process";
+import spawn from "cross-spawn";
 import { describe, expect, it } from "vitest";
 
-function claudeIsAvailable(): boolean {
-  try {
-    execFileSync("claude", ["--version"], { stdio: "pipe", timeout: 10000 });
-    return true;
-  } catch {
-    return false;
-  }
+/**
+ * Runs the CLI and returns its combined output, whether it exits zero or not.
+ *
+ * cross-spawn rather than node:child_process for the same reason spawnClaude uses it: on
+ * Windows `claude` is a .cmd shim, which Node will not execute directly.
+ */
+function runClaude(args: string[]): string {
+  const result = spawn.sync("claude", args, {
+    encoding: "utf-8",
+    timeout: 20000,
+  });
+  if (result.error) return String(result.error.message ?? result.error);
+  return `${result.stdout ?? ""}${result.stderr ?? ""}`;
 }
 
-/** Runs the CLI and returns its combined output, whether it exits zero or not. */
-function runClaude(args: string[]): string {
-  try {
-    return execFileSync("claude", args, {
-      encoding: "utf-8",
-      stdio: "pipe",
-      timeout: 20000,
-    });
-  } catch (error) {
-    const e = error as { stdout?: string; stderr?: string; message?: string };
-    return `${e.stdout ?? ""}${e.stderr ?? ""}${e.message ?? ""}`;
-  }
+function claudeIsAvailable(): boolean {
+  const result = spawn.sync("claude", ["--version"], {
+    encoding: "utf-8",
+    timeout: 10000,
+  });
+  return !result.error && result.status === 0;
 }
 
 const MISSING = "/pi-claude-cli-does-not-exist-9f3a2b.txt";

--- a/tests/cli-contract.test.ts
+++ b/tests/cli-contract.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Contract tests against the real Claude CLI.
+ *
+ * Every other test mocks `cross-spawn`, which is what let a flag bug ship: the package passed a
+ * file path to `--append-system-prompt`, a flag that takes literal text, so the system prompt
+ * was replaced by a path string and never reached the model. A mocked spawn asserts the
+ * argv the package builds; it cannot assert that the CLI means what the package assumes.
+ *
+ * These tests cost no model call and need no authentication. Claude Code validates flags and
+ * resolves the prompt file before it contacts anything, so an invalid path is enough to prove
+ * both that the flag exists and that it is read as a path.
+ *
+ * They skip when `claude` is not on PATH, so they are inert in an environment without the CLI.
+ */
+
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+function claudeIsAvailable(): boolean {
+  try {
+    execFileSync("claude", ["--version"], { stdio: "pipe", timeout: 10000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Runs the CLI and returns its combined output, whether it exits zero or not. */
+function runClaude(args: string[]): string {
+  try {
+    return execFileSync("claude", args, {
+      encoding: "utf-8",
+      stdio: "pipe",
+      timeout: 20000,
+    });
+  } catch (error) {
+    const e = error as { stdout?: string; stderr?: string; message?: string };
+    return `${e.stdout ?? ""}${e.stderr ?? ""}${e.message ?? ""}`;
+  }
+}
+
+const MISSING = "/pi-claude-cli-does-not-exist-9f3a2b.txt";
+
+describe.skipIf(!claudeIsAvailable())("Claude CLI flag contract", () => {
+  it("rejects a flag it does not know, which is how the other assertions have teeth", () => {
+    const output = runClaude([
+      "--append-system-prompt-does-not-exist",
+      MISSING,
+      "-p",
+      "",
+    ]);
+
+    expect(output).toMatch(/unknown option/i);
+  });
+
+  it("accepts --append-system-prompt-file and reads it as a path", () => {
+    const output = runClaude([
+      "--append-system-prompt-file",
+      MISSING,
+      "-p",
+      "",
+    ]);
+
+    // Not an unknown option: the flag the package depends on exists.
+    expect(output).not.toMatch(/unknown option/i);
+    // And it resolved the argument as a file rather than appending it as text, which is the
+    // whole reason this flag is the correct one.
+    expect(output).toContain(MISSING);
+    expect(output).toMatch(/not found/i);
+  });
+
+  it("treats --append-system-prompt as literal text, never as a path", () => {
+    const output = runClaude(["--append-system-prompt", MISSING, "-p", ""]);
+
+    expect(output).not.toMatch(/unknown option/i);
+    // A missing file is not an error here, because the path was appended as prose. If this
+    // ever starts reporting a missing file, the two flags have converged and the temp-file
+    // indirection in spawnClaude could be reconsidered.
+    expect(output).not.toMatch(/not found/i);
+  });
+});

--- a/tests/process-manager.test.ts
+++ b/tests/process-manager.test.ts
@@ -91,13 +91,22 @@ describe("spawnClaude", () => {
     expect(options.cwd).toBe("/custom/path");
   });
 
-  it("writes system prompt to temp file and passes path via --append-system-prompt", () => {
+  it("writes system prompt to temp file and passes its path via --append-system-prompt-file", () => {
     spawnClaude("claude-sonnet-4-5-20250929", "You are a helpful assistant.");
     const args = (spawn as any).mock.calls[0][1] as string[];
 
-    expect(args).toContain("--append-system-prompt");
-    const idx = args.indexOf("--append-system-prompt");
+    expect(args).toContain("--append-system-prompt-file");
+    const idx = args.indexOf("--append-system-prompt-file");
     expect(args[idx + 1]).toContain("pi-claude-cli-sysprompt-");
+  });
+
+  // --append-system-prompt takes literal text. Passing it a path appends the path itself and
+  // the prompt never reaches the model, which is silent because a path is valid text.
+  it("never passes a path to the literal-text flag", () => {
+    spawnClaude("claude-sonnet-4-5-20250929", "You are a helpful assistant.");
+    const args = (spawn as any).mock.calls[0][1] as string[];
+
+    expect(args).not.toContain("--append-system-prompt");
   });
 
   it("temp file contains the system prompt text", () => {
@@ -110,9 +119,10 @@ describe("spawnClaude", () => {
     expect(readFileSync(tmpFile, "utf-8")).toBe("You are a helpful assistant.");
   });
 
-  it("does not include --append-system-prompt when no system prompt", () => {
+  it("does not include --append-system-prompt-file when no system prompt", () => {
     spawnClaude("claude-sonnet-4-5-20250929");
     const args = (spawn as any).mock.calls[0][1] as string[];
+    expect(args).not.toContain("--append-system-prompt-file");
     expect(args).not.toContain("--append-system-prompt");
   });
 
@@ -175,7 +185,7 @@ describe("effort flag", () => {
     });
     const args = (spawn as any).mock.calls[0][1] as string[];
 
-    expect(args).toContain("--append-system-prompt");
+    expect(args).toContain("--append-system-prompt-file");
     expect(args).not.toContain("--effort");
   });
 });
@@ -419,7 +429,7 @@ describe("mcp-config flag", () => {
     });
     const args = (spawn as any).mock.calls[0][1] as string[];
 
-    expect(args).toContain("--append-system-prompt");
+    expect(args).toContain("--append-system-prompt-file");
     expect(args).toContain("--effort");
     expect(args).not.toContain("--mcp-config");
     expect(args).toContain("--permission-prompt-tool");

--- a/tests/provider.test.ts
+++ b/tests/provider.test.ts
@@ -1891,6 +1891,7 @@ describe("streamViaCli", () => {
 
       const args = (spawn as any).mock.calls[0][1] as string[];
       expect(args).toContain("--resume");
+      expect(args).not.toContain("--append-system-prompt-file");
       expect(args).not.toContain("--append-system-prompt");
 
       // Clean up


### PR DESCRIPTION
## The bug

`spawnClaude` writes the system prompt to a temp file, then passes that path to
`--append-system-prompt`:

```ts
writeFileSync(tmpFile, systemPrompt, "utf-8");
args.push("--append-system-prompt", tmpFile);
```

`--append-system-prompt` takes **literal text**. What reaches the model is the path string, not
the file's contents. The prompt is never delivered, and nothing reports it — a path is valid
text, so the CLI has nothing to complain about.

The correct flag is `--append-system-prompt-file`, which takes a path and reads it.

## Impact

Every session started through this provider runs without the host's system prompt. Under pi
that means no context files (`AGENTS.md`) and no skill catalogue. On the setup where I found
it, 27,893 bytes of system prompt were replaced by a 48-character path.

It persists for the whole session: the prompt is only sent on the first turn, and later turns
use `--resume`.

It has been there since the initial implementation (`41bc15b`).

## Reproduction

No pi needed — the CLI shows it directly. Tools are denied so the model cannot read the file
itself, which is what makes the current behaviour look like it works:

```console
$ echo "The passphrase is PROPERFILE-4410." > /tmp/sp.txt

$ claude --append-system-prompt-file /tmp/sp.txt -p \
    "State the passphrase from your instructions, or NONE. Do not use any tools."
PROPERFILE-4410

$ claude --append-system-prompt /tmp/sp.txt -p \
    "State the passphrase from your instructions, or NONE. Do not use any tools."
I have no passphrase in my instructions.
```

End to end through pi, before and after the change, same prompt and tools denied:

| | working agreement | skill catalogue |
|---|---|---|
| before | `NONE` | `NO SCOPE-CHECK` |
| after | marker returned verbatim | description quoted verbatim |

Checked against Claude Code `2.1.219` and `2.1.241`.

## The temp file stays

It is not the problem, and it is load-bearing: at ~28 KB, passing the prompt inline would sit
against Windows' 32,767-character command-line limit, which is what the indirection was for.
Only the flag was wrong.

## Why no test caught it

Every existing test mocks `cross-spawn`, so they assert the argv this package builds and cannot
assert what the CLI does with it. The old test asserted the bug faithfully.

`tests/cli-contract.test.ts` closes that gap by running the real binary. It **costs no model
call and needs no authentication** — Claude Code validates flags and resolves the prompt file
before contacting anything, so a non-existent path is enough to distinguish:

- unknown flag → `error: unknown option '...'`
- `--append-system-prompt-file` → `Error: Append system prompt file not found: ...` (exists, and reads a path)
- `--append-system-prompt` → neither (appended as prose)

The suite skips when `claude` is not on `PATH`, so the three CI runners are unaffected —
verified by running it with `claude` off `PATH`.

## Note on the flag

`--append-system-prompt-file` has no standalone entry in `claude --help` and is not in the
public CLI reference, though `claude --help` does reference it (`--append-system-prompt[-file]`)
under `--simple`, and the CLI rejects genuinely unknown options, so it is parsed rather than
ignored. Its original request, anthropics/claude-code#6153, was closed as not planned, yet the
flag is present and working in current builds.

If you would rather not depend on it, the alternative is passing the prompt inline and accepting
the Windows length risk, or probing once and falling back. Happy to rework it either way.

## Verification

`npm test` (300 pass, 10 files), `npm run typecheck`, `npm run lint`, `npm run format:check` all
clean. Reverting the one-word change fails 4 tests, including the new named one.
