### PR TITLE
fix: keep the user's question when an extension appends its own user message

### DIFF
--- a/src/prompt-builder.ts
+++ b/src/prompt-builder.ts
@@ -165,10 +165,14 @@ export function buildResumePrompt(context: {
   const newMessages: any[] = [];
 
   // Walk backwards from finalUserIndex to find where new content starts.
-  // Include trailing toolResult messages that follow the last assistant turn.
+  // Include trailing toolResult messages that follow the last assistant turn, and any
+  // earlier user messages in the same turn: an extension can append its own user message
+  // after the human's one (pi's plan mode injects a "[PLAN MODE ACTIVE]" preamble that way).
+  // Starting at the LAST user message alone would send only that preamble and silently drop
+  // the question the human actually asked.
   let startIdx = finalUserIndex;
   for (let i = finalUserIndex - 1; i >= 0; i--) {
-    if (messages[i].role === "toolResult") {
+    if (messages[i].role === "toolResult" || messages[i].role === "user") {
       startIdx = i;
     } else {
       break;

--- a/tests/prompt-builder.test.ts
+++ b/tests/prompt-builder.test.ts
@@ -924,6 +924,25 @@ describe("buildResumePrompt", () => {
     expect(buildResumePrompt(context)).toBe("Hello world");
   });
 
+  it("keeps the human's question when an extension appends its own user message", () => {
+    // pi's plan mode injects a "[PLAN MODE ACTIVE]" preamble as a user message after the
+    // human's. Starting from the last user message alone sent only the preamble, so the
+    // model was asked to plan with no task and answered with nothing.
+    const context = {
+      messages: [
+        { role: "user", content: "write me a plan" },
+        {
+          role: "user",
+          customType: "plan-mode-context",
+          content: "[PLAN MODE ACTIVE] read-only exploration",
+        },
+      ],
+    };
+    const prompt = buildResumePrompt(context);
+    expect(prompt).toContain("write me a plan");
+    expect(prompt).toContain("[PLAN MODE ACTIVE]");
+  });
+
   it("extracts only the last user message from a multi-turn conversation", () => {
     const context = {
       messages: [


### PR DESCRIPTION
`buildResumePrompt` starts at the last user message and walks backwards over `toolResult`
messages only, so any earlier user message in the same turn is excluded from the prompt.

That is the normal shape whenever a pi extension injects context. Plan mode appends its
`[PLAN MODE ACTIVE]` preamble as a user message from `before_agent_start`, so the resume
prompt became the preamble alone and the human's question was dropped.

The preamble ends with *"Do NOT attempt to make changes - just describe what you would do"*.
The model therefore received an instruction to plan with nothing to plan, and answered with
nothing at all.

### How it shows up

Observed on Linux against pi 0.84.4: three consecutive assistant turns with zero content
blocks and zero tokens, while the same prompts on a non-adapter provider worked normally.
Because nothing errors, it reads to the user as "plan mode is broken with Claude".

Ruled out the alternative reading: when the adapter succeeds it reports real token counts, so
the zero-token turns were genuinely empty rather than an accounting artefact.

### The change

The backwards walk now also spans `user` messages, so both the question and the injected
preamble reach the model — in either order, since an extension may inject before or after.

### Test

`keeps the human's question when an extension appends its own user message` asserts both
strings survive. It fails on the current behaviour (verified by reverting the one-line change)
and needs no model call. Full suite: 301 passing.

---

Independent of #39, which fixes a different silent failure in the same file. Both are carried
in a fork we install from, but they belong here.